### PR TITLE
fix tests on v1.0.0

### DIFF
--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -1,4 +1,4 @@
-var hyperdb = require('hyperdb')
+var hyperdb = require('../..')
 
 module.exports = create
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2,7 +2,7 @@ var create = require('./helpers/create')
 var replicate = require('./helpers/replicate')
 var tape = require('tape')
 
-var hyperdb = require('hyperdb')
+var hyperdb = require('..')
 var hypercore = require('hypercore')
 var ram = require('random-access-memory')
 


### PR DESCRIPTION
tests referenced 'hyperdb' instead of '..' or '../..'