### PR TITLE
Fixes: Cannot find module 'hyperdb'

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var hyperdb = require('hyperdb')
+var hyperdb = require('./')
 
 var db = hyperdb('./my.db', {valueEncoding: 'utf-8'})
 


### PR DESCRIPTION
I just noticed the difference of this particular detail because i was trying out the hypercore example minutes before.