### PR TITLE
feature: db.createDiffStream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ db.watch('/foo/bar', function () {
 db.put('/foo/bar/baz', 'hi') // triggers the above
 ```
 
+#### `db.snapshot(cb)`
+
+Return an object capturing the current state of `db` via the callback `cb` as
+`function (err, at)`. This object `at` can be passed into `db.createDiffStream`.
+
+#### `var stream = db.createDiffStream(key[, at])`
+
+Find out about changes in key/value pairs between the snapshot `at` and now for
+all keys prefixed by `key`.
+
+`stream` is a readable object stream that outputs modifications like
+
+```js
+{ type: 'del', name: '/a', value: '1' },
+{ type: 'put', name: '/a', value: '2' }
+{ type: 'put', name: '/b/beep', value: 'boop' }
+```
+
+that occured between `at` and the time of calling the function.
+
 #### `var stream = db.replicate([options])`
 
 Create a replication stream. Options include:

--- a/README.md
+++ b/README.md
@@ -134,12 +134,13 @@ time.
 `stream` is a readable object stream that outputs modifications like
 
 ```js
-{ type: 'del', name: '/a', value: '1' },
-{ type: 'put', name: '/a', value: '2' }
-{ type: 'put', name: '/b/beep', value: 'boop' }
+{ type: 'del', name: '/a', value: ['1'] },
+{ type: 'put', name: '/a', value: ['2'] }
+{ type: 'put', name: '/b/beep', value: ['boop', 'beep'] }
 ```
 
-that occured between `checkout` and `head`.
+that occured between `checkout` and `head`. When multiple feeds conflict for the
+value of a key at a point in time, `value` will have multiple entries.
 
 #### `var stream = db.replicate([options])`
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ db.put('/foo/bar/baz', 'hi') // triggers the above
 Return an object capturing the current state of `db` via the callback `cb` as
 `function (err, at)`. This object `at` can be passed into `db.createDiffStream`.
 
-#### `var stream = db.createDiffStream(key[, at])`
+#### `var stream = db.createDiffStream(key[, at][, opts])`
 
 Find out about changes in key/value pairs between the snapshot `at` and now for
 all keys prefixed by `key`.
@@ -136,6 +136,11 @@ all keys prefixed by `key`.
 ```
 
 that occured between `at` and the time of calling the function.
+
+Valid `opts` include:
+
+- `opts.head` (optional): a snapshot to use as the HEAD to compare against. If
+  not provided, the current HEAD of the database is used.
 
 #### `var stream = db.replicate([options])`
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,14 @@ db.put('/foo/bar/baz', 'hi') // triggers the above
 Return an object capturing the current state of `db` via the callback `cb` as
 `function (err, at)`. This object `at` can be passed into `db.createDiffStream`.
 
-#### `var stream = db.createDiffStream(key[, at][, opts])`
+#### `var stream = db.createDiffStream(key[, checkout][, head])`
 
-Find out about changes in key/value pairs between the snapshot `at` and now for
-all keys prefixed by `key`.
+Find out about changes in key/value pairs between the snapshot `checkout` and
+`head` for all keys prefixed by `key`.
+
+`checkout` and `head` are snapshots to use to compare against. If not provided,
+`head is the current HEAD of the database, and `checkout` is the beginning of
+time.
 
 `stream` is a readable object stream that outputs modifications like
 
@@ -135,12 +139,7 @@ all keys prefixed by `key`.
 { type: 'put', name: '/b/beep', value: 'boop' }
 ```
 
-that occured between `at` and the time of calling the function.
-
-Valid `opts` include:
-
-- `opts.head` (optional): a snapshot to use as the HEAD to compare against. If
-  not provided, the current HEAD of the database is used.
+that occured between `checkout` and `head`.
 
 #### `var stream = db.replicate([options])`
 

--- a/index.js
+++ b/index.js
@@ -667,7 +667,10 @@ DB.prototype._visitGet = function (key, path, i, node, heads, result, onvisit, c
 //
 // For now, this is NOT a live stream. History at call-time is compared against
 // 'checkout'.
-DB.prototype.createDiffStream = function (checkout, key) {
+DB.prototype.createDiffStream = function (key, checkout) {
+  // Diff from the beginning
+  if (!checkout) checkout = []
+
   var stream = new Readable({objectMode: true})
   stream._read = noop
 

--- a/index.js
+++ b/index.js
@@ -767,8 +767,6 @@ DB.prototype._visitTrie = function (key, path, node, head, snapshot, halt, visit
   cb = once(cb)
 
   var id = node.feed + ',' + node.seq
-
-  if (visited[id]) return cb()
   visited[id] = true
 
   // We've traveled past 'snapshot' -- bail.
@@ -804,8 +802,10 @@ DB.prototype._visitTrie = function (key, path, node, head, snapshot, halt, visit
       var entrySet = trie[i] || []
       for (var j = 0; j < entrySet.length; j++) {
         var entry = entrySet[j]
+
         id = entry.feed + ',' + entry.seq
         if (visited[id]) continue
+        visited[id] = true
 
         missing++
         self._writers[entry.feed].get(entry.seq, function (err, node) {

--- a/index.js
+++ b/index.js
@@ -811,10 +811,12 @@ function diffNodeSets (a, b) {
   var ak = Object.keys(a)
   var result = []
   for (var i = 0; i < ak.length; i++) {
-    if (a[ak[i]] && b[ak[i]]) {
+    var A = a[ak[i]]
+    var B = b[ak[i]]
+    if (A && B && A !== B) {
       result.push({ type: 'del', name: ak[i], value: b[ak[i]].value })
       result.push({ type: 'put', name: ak[i], value: a[ak[i]].value })
-    } else if (a[ak[i]] && !b[ak[i]]) {
+    } else if (A && (!B || A === B)) {
       result.push({ type: 'put', name: ak[i], value: a[ak[i]].value })
     }
   }

--- a/index.js
+++ b/index.js
@@ -695,7 +695,8 @@ DB.prototype.createDiffStream = function (key, checkout) {
   })
 
   // 2: Walk the trie starting at CHECKOUT
-  for (var i = 0; checkout && i < Object.keys(checkout).length; i++) {
+  var keys = Object.keys(checkout || {})
+  for (var i = 0; i < keys.length; i++) {
     var elm = checkout[i]
     missing++
     self._writers[i].get(elm, function (err, node) {
@@ -780,10 +781,10 @@ DB.prototype._visitTrie = function (key, path, node, head, checkout, halt, cb) {
 
   // Traverse the node's entire trie, recursively, hunting for more nodes with
   // the desired prefix.
-  var trie = node.trie[i]
-  for (i = 0; trie && i < trie.length; i++) {
-    var entrySet = trie[i]
-    for (var j = 0; entrySet && j < entrySet.length; j++) {
+  var trie = node.trie[i] || []
+  for (i = 0; i < trie.length; i++) {
+    var entrySet = trie[i] || []
+    for (var j = 0; j < entrySet.length; j++) {
       var entry = entrySet[j]
       missing++
       self._writers[entry.feed].get(entry.seq, function (err, node) {
@@ -794,10 +795,6 @@ DB.prototype._visitTrie = function (key, path, node, head, checkout, halt, cb) {
         })
       })
     }
-  }
-
-  function onMismatch () {
-    if (!--missing) fin(null)
   }
 
   if (!missing) fin(null)

--- a/index.js
+++ b/index.js
@@ -662,14 +662,13 @@ DB.prototype._visitGet = function (key, path, i, node, heads, result, onvisit, c
 
 // Return a Readable stream of changes to a hyperdb since 'checkout', an array
 // of { feed: id, seq: Number}.
-// If 'key' is provided, only diff entries with a prefix of 'key' will be
-// included.
+//
+// If 'checkout' is not provided, the beginning of history is compared against.
 //
 // For now, this is NOT a live stream. History at call-time is compared against
 // 'checkout'.
 DB.prototype.createDiffStream = function (key, checkout) {
-  // Diff from the beginning
-  if (!checkout) checkout = []
+  if (!checkout) checkout = []  // Diff from the beginning
 
   var stream = new Readable({objectMode: true})
   stream._read = noop

--- a/index.js
+++ b/index.js
@@ -713,6 +713,7 @@ DB.prototype.createDiffStream = function (key, at, opts) {
     cb = once(cb)
     var result = []
     var keys = Object.keys(snapshot || {})
+    if (!keys.length) return cb(null, result)
     var pending = keys.length
     for (var i = 0; i < keys.length; i++) {
       var elm = snapshot[i]

--- a/index.js
+++ b/index.js
@@ -770,10 +770,26 @@ DB.prototype._visitDiff = function (key, path, node, initial, result, onvisit, h
     })
     console.log('head', a)
     console.log('checkout', b)
+    console.log(diffShallowObjects(a, b))
   }
 }
 
 function noop () {}
+
+function diffShallowObjects (a, b) {
+  var ak = Object.keys(a)
+  var bk = Object.keys(b)
+  var result = []
+  for (var i = 0; i < ak.length; i++) {
+    if (a[ak[i]] && b[ak[i]]) {
+      result.push({ type: 'del', name: ak[i], value: b[ak[i]] })
+      result.push({ type: 'put', name: ak[i], value: a[ak[i]] })
+    } else if (a[ak[i]] && !b[ak[i]]) {
+      result.push({ type: 'put', name: ak[i], value: a[ak[i]] })
+    }
+  }
+  return result
+}
 
 function updateHead (newNode, oldNode, heads) {
   var i = heads.indexOf(oldNode)

--- a/index.js
+++ b/index.js
@@ -685,9 +685,11 @@ DB.prototype.createDiffStream = function (key, at) {
   // 1: Walk the trie starting at the head of all logs
   this.heads(function (err, heads) {
     if (err) return cb(err)
-    missing--
-    if (!heads.length) return cb(null, null)
+    if (!heads.length) {
+      return onDone(null, {})
+    }
 
+    missing--
     for (var i = 0; i < heads.length; i++) {
       missing++
       self._visitTrie(key, path, heads[i], {}, {}, at, onDone)
@@ -708,14 +710,12 @@ DB.prototype.createDiffStream = function (key, at) {
   var a, b
 
   function onDone2 (err, result) {
-    // console.log('res2', result)
     if (err) return cb(err)
     b = result
     if (!--missing) onAllDone()
   }
 
   function onDone (err, result) {
-    // console.log('res1', result)
     if (err) return cb(err)
     a = result
     if (!--missing) onAllDone()

--- a/index.js
+++ b/index.js
@@ -686,13 +686,13 @@ DB.prototype.createDiffStream = function (key, at) {
   this.heads(function (err, heads) {
     if (err) return cb(err)
     if (!heads.length) {
-      return onDone(null, {})
+      return onDoneFromHead(null, {})
     }
 
     missing--
     for (var i = 0; i < heads.length; i++) {
       missing++
-      self._visitTrie(key, path, heads[i], {}, {}, at, onDone)
+      self._visitTrie(key, path, heads[i], {}, {}, at, onDoneFromHead)
     }
   })
 
@@ -703,21 +703,21 @@ DB.prototype.createDiffStream = function (key, at) {
     missing++
     self._writers[i].get(elm, function (err, node) {
       if (err) return cb(err)
-      self._visitTrie(key, path, node, {}, {}, null, onDone2)
+      self._visitTrie(key, path, node, {}, {}, null, onDoneFromSnapshot)
     })
   }
 
   var a, b
 
-  function onDone2 (err, result) {
+  function onDoneFromHead (err, result) {
     if (err) return cb(err)
-    b = result
+    a = result
     if (!--missing) onAllDone()
   }
 
-  function onDone (err, result) {
+  function onDoneFromSnapshot (err, result) {
     if (err) return cb(err)
-    a = result
+    b = result
     if (!--missing) onAllDone()
   }
 

--- a/index.js
+++ b/index.js
@@ -667,29 +667,17 @@ DB.prototype._visitGet = function (key, path, i, node, heads, result, onvisit, c
 // For now, this is NOT a live stream. History at call-time is compared against
 // 'checkout'.
 DB.prototype.createDiffStream = function (checkout, key) {
-  // Q: how do traverse all keys recursively?
-  // A: I think I need to just read ALL entries since checkout from all writers
-
   var self = this
   var path = hash(key, true)
-  var result = {}
 
   this.heads(function (err, heads) {
     if (err) return cb(err)
     if (!heads.length) return cb(null, null)
 
     for (var i = 0; i < heads.length; i++) {
-      self._visitDiff(key, path, heads[i], {}, {}, visit, checkout, onget)
+      self._visitDiff(key, path, heads[i], {}, {}, checkout, noop)
     }
   })
-
-  function visit (node, idx, bool) {
-    console.log('visit', node.key)
-  }
-
-  function onget () {
-    console.log('onget', result)
-  }
 }
 
 DB.prototype.checkout = function (cb) {
@@ -706,7 +694,7 @@ DB.prototype.checkout = function (cb) {
   })
 }
 
-DB.prototype._visitDiff = function (key, path, node, head, checkout, onvisit, halt, cb) {
+DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
   var self = this
   var missing = 0
 
@@ -743,7 +731,7 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, onvisit, ha
       var entry = entrySet[j]
       missing++
       self._writers[entry.feed].get(entry.seq, function (err, node) {
-        self._visitDiff(key, path, node, head, checkout, onvisit, halt, function () {
+        self._visitDiff(key, path, node, head, checkout, halt, function () {
           // TODO: handle error
           if (!--missing) fin(null)
         })

--- a/index.js
+++ b/index.js
@@ -681,7 +681,7 @@ DB.prototype.createDiffStream = function (key, checkout) {
     if (!heads.length) return cb(null, null)
 
     for (var i = 0; i < heads.length; i++) {
-      self._visitDiff(key, path, heads[i], {}, {}, checkout, onDone)
+      self._visitTrie(key, path, heads[i], {}, {}, checkout, onDone)
     }
   })
 
@@ -710,7 +710,7 @@ DB.prototype.checkout = function (cb) {
   })
 }
 
-DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
+DB.prototype._visitTrie = function (key, path, node, head, checkout, halt, cb) {
   var self = this
   var missing = 0
 
@@ -742,7 +742,7 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
       var entry = entrySet[j]
       missing++
       self._writers[entry.feed].get(entry.seq, function (err, node) {
-        self._visitDiff(key, path, node, head, checkout, halt, function () {
+        self._visitTrie(key, path, node, head, checkout, halt, function () {
           // TODO: handle error
           if (!--missing) fin(null)
         })

--- a/index.js
+++ b/index.js
@@ -714,7 +714,6 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
 
   // We've traveled past 'checkout' -- bail.
   if (halt[node.feed] && halt[node.feed] > node.seq) {
-    console.log('bailing at', node)
     return cb()
   }
 
@@ -722,17 +721,13 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
   for (var i = 0; i < path.length && path[i] !== hash.TERMINATE; i++) {
     if (path[i] !== node.path[i]) return onMismatch()
   }
-  console.log('full prefix match', node.key)
 
   // Mark this match as either the first time we've seen it (head), an older
   // value of this key we're still tracking backwards in time (checkout), or a
   // duplicate that we've already procesed (deduped).
   if (!head[node.key]) {
     head[node.key] = node
-  } else if (head[node.key].feed === node.feed && head[node.key].seq === node.seq) {
-    console.log('deduped', node.key)
-    console.log(head[node.key], node)
-  } else {
+  } else if (head[node.key].feed !== node.feed || head[node.key].seq !== node.seq) {
     checkout[node.key] = node
   }
 
@@ -754,7 +749,6 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
   }
 
   function onMismatch () {
-    console.log('mismatch', i, missing)
     if (!--missing) fin(null)
   }
 

--- a/index.js
+++ b/index.js
@@ -696,6 +696,9 @@ DB.prototype.createDiffStream = function (key, checkout, head) {
   // 2: Walk the trie starting at CHECKOUT
   snapshotToNodes(checkout, function (err, nodes) {
     if (err) return cb(err)
+    if (!nodes.length) {
+      return onDoneFromSnapshot(null, {})
+    }
     missing--
     missing += nodes.length
     var visited = {}

--- a/index.js
+++ b/index.js
@@ -697,7 +697,7 @@ DB.prototype.createDiffStream = function (checkout, key) {
 DB.prototype.checkout = function (cb) {
   this.heads(function (err, heads) {
     if (err) return cb(err)
-    if (!heads.length) return cb(null, null)
+    if (!heads.length) return cb(null, [])
 
     var result = {}
     for (var i = 0; i < heads.length; i++) {

--- a/index.js
+++ b/index.js
@@ -773,7 +773,7 @@ DB.prototype._visitTrie = function (key, path, node, head, snapshot, halt, cb) {
   cb = once(cb)
 
   // We've traveled past 'snapshot' -- bail.
-  if (halt && halt[node.feed] && halt[node.feed] > node.seq) {
+  if (halt && halt[node.feed] !== undefined && halt[node.feed] >= node.seq) {
     return cb()
   }
 

--- a/index.js
+++ b/index.js
@@ -661,9 +661,8 @@ DB.prototype._visitGet = function (key, path, i, node, heads, result, onvisit, c
   }
 }
 
-DB.prototype.createDiffStream = function (key, at, opts) {
-  if (!at) at = []  // Diff from the beginning
-  opts = opts || {}
+DB.prototype.createDiffStream = function (key, checkout, head) {
+  if (!checkout) checkout = []  // Diff from the beginning
 
   var stream = new Readable({objectMode: true})
   stream._read = noop
@@ -677,8 +676,8 @@ DB.prototype.createDiffStream = function (key, at, opts) {
   var missing = 1
 
   // 1: Walk the trie starting at the head of all logs
-  if (!opts.head) this.heads(onHeads)
-  else snapshotToNodes(opts.head, onHeads)
+  if (!head) this.heads(onHeads)
+  else snapshotToNodes(head, onHeads)
 
   function onHeads (err, heads) {
     if (err) return cb(err)
@@ -689,12 +688,12 @@ DB.prototype.createDiffStream = function (key, at, opts) {
     missing--
     for (var i = 0; i < heads.length; i++) {
       missing++
-      self._visitTrie(key, path, heads[i], {}, {}, at, onDoneFromHead)
+      self._visitTrie(key, path, heads[i], {}, {}, checkout, onDoneFromHead)
     }
   }
 
   // 2: Walk the trie starting at CHECKOUT
-  snapshotToNodes(at, function (err, nodes) {
+  snapshotToNodes(checkout, function (err, nodes) {
     if (err) return cb(err)
     missing += nodes.length
     for (var i = 0; i < nodes.length; i++) {

--- a/index.js
+++ b/index.js
@@ -781,19 +781,21 @@ DB.prototype._visitTrie = function (key, path, node, head, snapshot, halt, cb) {
 
   // Traverse the node's entire trie, recursively, hunting for more nodes with
   // the desired prefix.
-  var trie = node.trie[i] || []
-  for (i = 0; i < trie.length; i++) {
-    var entrySet = trie[i] || []
-    for (var j = 0; j < entrySet.length; j++) {
-      var entry = entrySet[j]
-      missing++
-      self._writers[entry.feed].get(entry.seq, function (err, node) {
-        if (err) return fin(null)
-        self._visitTrie(key, path, node, head, snapshot, halt, function (err) {
-          if (err) return fin(err)
-          if (!--missing) fin(null)
+  for (var k = 0; k < node.trie.length; k++) {
+    var trie = node.trie[k] || []
+    for (i = 0; i < trie.length; i++) {
+      var entrySet = trie[i] || []
+      for (var j = 0; j < entrySet.length; j++) {
+        var entry = entrySet[j]
+        missing++
+        self._writers[entry.feed].get(entry.seq, function (err, node) {
+          if (err) return fin(null)
+          self._visitTrie(key, path, node, head, snapshot, halt, function (err) {
+            if (err) return fin(err)
+            if (!--missing) fin(null)
+          })
         })
-      })
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -661,13 +661,6 @@ DB.prototype._visitGet = function (key, path, i, node, heads, result, onvisit, c
   }
 }
 
-// Return a Readable stream of changes to a hyperdb since 'at', an array
-// of { feed: id, seq: Number}.
-//
-// If 'at' is not provided, the beginning of history is compared against.
-//
-// For now, this is NOT a live stream. History at call-time is compared against
-// 'at'.
 DB.prototype.createDiffStream = function (key, at, opts) {
   if (!at) at = []  // Diff from the beginning
   opts = opts || {}

--- a/index.js
+++ b/index.js
@@ -748,32 +748,21 @@ DB.prototype._visitDiff = function (key, path, node, head, checkout, halt, cb) {
 
   // Finalize the results by taking a diff of 'head' and 'checkout'.
   function fin () {
-    var a = {}
-    Object.keys(head).map(function (k) {
-      a[k] = head[k].value
-    })
-    var b = {}
-    Object.keys(checkout).map(function (k) {
-      b[k] = checkout[k].value
-    })
-    console.log('head', a)
-    console.log('checkout', b)
-    console.log(diffShallowObjects(a, b))
+    console.log(diffNodeSets(head, checkout))
   }
 }
 
 function noop () {}
 
-function diffShallowObjects (a, b) {
+function diffNodeSets (a, b) {
   var ak = Object.keys(a)
-  var bk = Object.keys(b)
   var result = []
   for (var i = 0; i < ak.length; i++) {
     if (a[ak[i]] && b[ak[i]]) {
-      result.push({ type: 'del', name: ak[i], value: b[ak[i]] })
-      result.push({ type: 'put', name: ak[i], value: a[ak[i]] })
+      result.push({ type: 'del', name: ak[i], value: b[ak[i]].value })
+      result.push({ type: 'put', name: ak[i], value: a[ak[i]].value })
     } else if (a[ak[i]] && !b[ak[i]]) {
-      result.push({ type: 'put', name: ak[i], value: a[ak[i]] })
+      result.push({ type: 'put', name: ak[i], value: a[ak[i]].value })
     }
   }
   return result

--- a/index.js
+++ b/index.js
@@ -673,7 +673,7 @@ DB.prototype.createDiffStream = function (key, checkout, head) {
 
   var self = this
   var path = hash(key, true)
-  var missing = 1
+  var missing = 2
 
   // 1: Walk the trie starting at the head of all logs
   if (!head) this.heads(onHeads)
@@ -696,6 +696,7 @@ DB.prototype.createDiffStream = function (key, checkout, head) {
   // 2: Walk the trie starting at CHECKOUT
   snapshotToNodes(checkout, function (err, nodes) {
     if (err) return cb(err)
+    missing--
     missing += nodes.length
     var visited = {}
     for (var i = 0; i < nodes.length; i++) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "hypercore-protocol": "^6.4.0",
     "inherits": "^2.0.3",
     "mutexify": "^1.1.0",
+    "once": "^1.4.0",
     "protocol-buffers": "^3.2.1",
     "random-access-file": "^1.8.1",
     "sodium-universal": "^1.4.0",

--- a/test/diff.js
+++ b/test/diff.js
@@ -79,7 +79,7 @@ tape('two new values', function (t) {
   })
 })
 
-tape('opts.head', function (t) {
+tape('set head', function (t) {
   var db = create.one()
 
   var expected = [
@@ -94,7 +94,7 @@ tape('opts.head', function (t) {
         t.error(err, 'no error')
         db.put('/a/bar', 'baz', function (err) {
           t.error(err, 'no error')
-          var rs = db.createDiffStream('/a', co1, { head: co2 })
+          var rs = db.createDiffStream('/a', co1, co2)
           collect(rs, function (err, actual) {
             t.error(err, 'no error')
             t.deepEqual(actual, expected, 'diff as expected')
@@ -106,7 +106,7 @@ tape('opts.head', function (t) {
   })
 })
 
-tape('opts.head 2', function (t) {
+tape('set head 2', function (t) {
   var db = create.one()
 
   var expected = [
@@ -121,7 +121,7 @@ tape('opts.head 2', function (t) {
         t.error(err, 'no error')
         db.snapshot(function (err, co2) {
           t.error(err, 'no error')
-          var rs = db.createDiffStream('/a', co1, { head: co2 })
+          var rs = db.createDiffStream('/a', co1, co2)
           collect(rs, function (err, actual) {
             t.error(err, 'no error')
             t.deepEqual(actual, expected, 'diff as expected')

--- a/test/diff.js
+++ b/test/diff.js
@@ -37,28 +37,51 @@ tape('new value', function (t) {
   })
 })
 
-tape('updated value', function (t) {
+tape('untracked value', function (t) {
   var db = create.one()
 
   var expected = [
-    { type: 'del', name: '/a/d/r', value: '1' },
-    { type: 'put', name: '/a/d/r', value: '3' },
+    { type: 'del', name: '/a', value: '1' },
     { type: 'put', name: '/a', value: '2' }
   ]
 
-  db.put('/a/d/r', '1', function (err) {
+  db.put('/a', '1', function (err) {
     t.error(err, 'no error')
     db.checkout(function (err, co) {
       t.error(err, 'no error')
       db.put('/a', '2', function (err) {
         t.error(err, 'no error')
-        db.put('/a/d/r', '3', function (err) {
+        db.put('/b', '17', function (err) {
           t.error(err, 'no error')
           var rs = db.createDiffStream('/a', co)
           collect(rs, function (err, actual) {
             t.deepEqual(actual, expected, 'diff as expected')
             t.end()
           })
+        })
+      })
+    })
+  })
+})
+
+tape('updated value', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'del', name: '/a/d/r', value: '1' },
+    { type: 'put', name: '/a/d/r', value: '3' }
+  ]
+
+  db.put('/a/d/r', '1', function (err) {
+    t.error(err, 'no error')
+    db.checkout(function (err, co) {
+      t.error(err, 'no error')
+      db.put('/a/d/r', '3', function (err) {
+        t.error(err, 'no error')
+        var rs = db.createDiffStream('/a', co)
+        collect(rs, function (err, actual) {
+          t.deepEqual(actual, expected, 'diff as expected')
+          t.end()
         })
       })
     })

--- a/test/diff.js
+++ b/test/diff.js
@@ -79,6 +79,33 @@ tape('two new values', function (t) {
   })
 })
 
+tape('opts.head', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a/foo', value: 'quux' }
+  ]
+
+  db.snapshot(function (err, co1) {
+    t.error(err, 'no error')
+    db.put('/a/foo', 'quux', function (err) {
+      t.error(err, 'no error')
+      db.snapshot(function (err, co2) {
+        t.error(err, 'no error')
+        db.put('/a/bar', 'baz', function (err) {
+          t.error(err, 'no error')
+          var rs = db.createDiffStream('/a', co1, { head: co2 })
+          collect(rs, function (err, actual) {
+            t.error(err, 'no error')
+            t.deepEqual(actual, expected, 'diff as expected')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
 tape('checkout === head', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -114,6 +114,36 @@ tape('untracked value', function (t) {
   })
 })
 
+tape('diff root', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/b', value: '17' },
+    { type: 'del', name: '/a', value: '1' },
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.put('/a', '1', function (err) {
+    t.error(err, 'no error')
+    db.snapshot(function (err, co) {
+      t.error(err, 'no error')
+      db.put('/a', '2', function (err) {
+        t.error(err, 'no error')
+        db.put('/b', '17', function (err) {
+          t.error(err, 'no error')
+          var rs = db.createDiffStream('/', co)
+          collect(rs, function (err, actual) {
+            t.error(err, 'no error')
+            t.deepEqual(actual, expected, 'diff as expected')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+
 tape('updated value', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -106,6 +106,33 @@ tape('opts.head', function (t) {
   })
 })
 
+tape('opts.head 2', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a/bar', value: 'baz' }
+  ]
+
+  db.put('/a/foo', 'quux', function (err) {
+    t.error(err, 'no error')
+    db.snapshot(function (err, co1) {
+      t.error(err, 'no error')
+      db.put('/a/bar', 'baz', function (err) {
+        t.error(err, 'no error')
+        db.snapshot(function (err, co2) {
+          t.error(err, 'no error')
+          var rs = db.createDiffStream('/a', co1, { head: co2 })
+          collect(rs, function (err, actual) {
+            t.error(err, 'no error')
+            t.deepEqual(actual, expected, 'diff as expected')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
 tape('checkout === head', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -2,6 +2,19 @@ var tape = require('tape')
 var create = require('./helpers/create')
 var replicate = require('./helpers/replicate')
 
+tape('empty diff', function (t) {
+  var db = create.one()
+
+  var expected = []
+
+  var rs = db.createDiffStream('/a')
+  collect(rs, function (err, actual) {
+    t.error(err, 'no error')
+    t.deepEqual(actual, expected, 'diff as expected')
+    t.end()
+  })
+})
+
 tape('implicit checkout', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -12,6 +12,7 @@ tape('implicit checkout', function (t) {
     t.error(err, 'no error')
     var rs = db.createDiffStream('/a')
     collect(rs, function (err, actual) {
+      t.error(err, 'no error')
       t.deepEqual(actual, expected, 'diff as expected')
       t.end()
     })
@@ -26,10 +27,12 @@ tape('new value', function (t) {
   ]
 
   db.checkout(function (err, co) {
+    t.error(err, 'no error')
     db.put('/a', '2', function (err) {
       t.error(err, 'no error')
       var rs = db.createDiffStream('/a', co)
       collect(rs, function (err, actual) {
+        t.error(err, 'no error')
         t.deepEqual(actual, expected, 'diff as expected')
         t.end()
       })
@@ -45,12 +48,14 @@ tape('new value, twice', function (t) {
   ]
 
   db.checkout(function (err, co) {
+    t.error(err, 'no error')
     db.put('/a', '1', function (err) {
       t.error(err, 'no error')
       db.put('/a', '2', function (err) {
         t.error(err, 'no error')
         var rs = db.createDiffStream('/a', co)
         collect(rs, function (err, actual) {
+          t.error(err, 'no error')
           t.deepEqual(actual, expected, 'diff as expected')
           t.end()
         })
@@ -77,6 +82,7 @@ tape('untracked value', function (t) {
           t.error(err, 'no error')
           var rs = db.createDiffStream('/a', co)
           collect(rs, function (err, actual) {
+            t.error(err, 'no error')
             t.deepEqual(actual, expected, 'diff as expected')
             t.end()
           })
@@ -102,6 +108,7 @@ tape('updated value', function (t) {
         t.error(err, 'no error')
         var rs = db.createDiffStream('/a', co)
         collect(rs, function (err, actual) {
+          t.error(err, 'no error')
           t.deepEqual(actual, expected, 'diff as expected')
           t.end()
         })

--- a/test/diff.js
+++ b/test/diff.js
@@ -41,6 +41,27 @@ tape('new value', function (t) {
   })
 })
 
+tape('checkout === head', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    db.snapshot(function (err, co) {
+      t.error(err, 'no error')
+      var rs = db.createDiffStream('/a', co)
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.deepEqual(actual, expected, 'diff as expected')
+        t.end()
+      })
+    })
+  })
+})
+
 tape('new value, twice', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -88,6 +88,8 @@ tape('updated value', function (t) {
   })
 })
 
+// TODO: multiple feeds
+
 function collect (stream, cb) {
   var res = []
   stream.on('data', res.push.bind(res))

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,0 +1,37 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+
+function collect (stream, cb) {
+  var res = []
+  stream.on('data', res.push.bind(res))
+  stream.once('error', cb)
+  stream.once('end', cb.bind(null, null, res))
+}
+
+tape('basic put/get', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'del', name: '/a/d/r', value: '1' },
+    { type: 'put', name: '/a/d/r', value: '3' },
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.put('/a/d/r', '1', function (err) {
+    t.error(err, 'no error')
+    db.checkout(function (err, co) {
+      t.error(err, 'no error')
+      db.put('/a', '2', function (err) {
+        t.error(err, 'no error')
+        db.put('/a/d/r', '3', function (err) {
+          t.error(err, 'no error')
+          var rs = db.createDiffStream(co, '/a')
+          collect(rs, function (err, actual) {
+            t.deepEqual(actual, expected, 'diff as expected')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/diff.js
+++ b/test/diff.js
@@ -27,7 +27,7 @@ tape('new value', function (t) {
     { type: 'put', name: '/a', value: '2' }
   ]
 
-  db.checkout(function (err, co) {
+  db.snapshot(function (err, co) {
     t.error(err, 'no error')
     db.put('/a', '2', function (err) {
       t.error(err, 'no error')
@@ -48,7 +48,7 @@ tape('new value, twice', function (t) {
     { type: 'put', name: '/a', value: '2' }
   ]
 
-  db.checkout(function (err, co) {
+  db.snapshot(function (err, co) {
     t.error(err, 'no error')
     db.put('/a', '1', function (err) {
       t.error(err, 'no error')
@@ -75,7 +75,7 @@ tape('untracked value', function (t) {
 
   db.put('/a', '1', function (err) {
     t.error(err, 'no error')
-    db.checkout(function (err, co) {
+    db.snapshot(function (err, co) {
       t.error(err, 'no error')
       db.put('/a', '2', function (err) {
         t.error(err, 'no error')
@@ -103,7 +103,7 @@ tape('updated value', function (t) {
 
   db.put('/a/d/r', '1', function (err) {
     t.error(err, 'no error')
-    db.checkout(function (err, co) {
+    db.snapshot(function (err, co) {
       t.error(err, 'no error')
       db.put('/a/d/r', '3', function (err) {
         t.error(err, 'no error')

--- a/test/diff.js
+++ b/test/diff.js
@@ -54,6 +54,31 @@ tape('new value', function (t) {
   })
 })
 
+tape('two new values', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a/bar', value: 'baz' },
+    { type: 'put', name: '/a/foo', value: 'quux' }
+  ]
+
+  db.snapshot(function (err, co) {
+    t.error(err, 'no error')
+    db.put('/a/foo', 'quux', function (err) {
+      t.error(err, 'no error')
+      db.put('/a/bar', 'baz', function (err) {
+        t.error(err, 'no error')
+        var rs = db.createDiffStream('/a', co)
+        collect(rs, function (err, actual) {
+          t.error(err, 'no error')
+          t.deepEqual(actual, expected, 'diff as expected')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 tape('checkout === head', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,6 +1,23 @@
 var tape = require('tape')
 var create = require('./helpers/create')
 
+tape('implicit checkout', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    var rs = db.createDiffStream('/a')
+    collect(rs, function (err, actual) {
+      t.deepEqual(actual, expected, 'diff as expected')
+      t.end()
+    })
+  })
+})
+
 tape('new value', function (t) {
   var db = create.one()
 
@@ -11,7 +28,7 @@ tape('new value', function (t) {
   db.checkout(function (err, co) {
     db.put('/a', '2', function (err) {
       t.error(err, 'no error')
-      var rs = db.createDiffStream(co, '/a')
+      var rs = db.createDiffStream('/a', co)
       collect(rs, function (err, actual) {
         t.deepEqual(actual, expected, 'diff as expected')
         t.end()
@@ -37,7 +54,7 @@ tape('updated value', function (t) {
         t.error(err, 'no error')
         db.put('/a/d/r', '3', function (err) {
           t.error(err, 'no error')
-          var rs = db.createDiffStream(co, '/a')
+          var rs = db.createDiffStream('/a', co)
           collect(rs, function (err, actual) {
             t.deepEqual(actual, expected, 'diff as expected')
             t.end()

--- a/test/diff.js
+++ b/test/diff.js
@@ -181,7 +181,6 @@ tape('diff root', function (t) {
   })
 })
 
-
 tape('updated value', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -110,7 +110,6 @@ tape('checkout === head', function (t) {
   var db = create.one()
 
   var expected = [
-    { type: 'put', name: '/a', value: '2' }
   ]
 
   db.put('/a', '2', function (err) {

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,5 +1,6 @@
 var tape = require('tape')
 var create = require('./helpers/create')
+var replicate = require('./helpers/replicate')
 
 tape('implicit checkout', function (t) {
   var db = create.one()
@@ -117,7 +118,26 @@ tape('updated value', function (t) {
   })
 })
 
-// TODO: multiple feeds
+tape('basic with 2 feeds', function (t) {
+  var expected = [
+    { type: 'put', name: '/a', value: 'a' }
+  ]
+
+  create.two(function (a, b) {
+    a.put('/a', 'a', function () {
+      replicate(a, b, validate)
+    })
+
+    function validate () {
+      var rs = b.createDiffStream('/a')
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.deepEqual(actual, expected, 'diff as expected')
+        t.end()
+      })
+    }
+  })
+})
 
 function collect (stream, cb) {
   var res = []

--- a/test/diff.js
+++ b/test/diff.js
@@ -37,6 +37,28 @@ tape('new value', function (t) {
   })
 })
 
+tape('new value, twice', function (t) {
+  var db = create.one()
+
+  var expected = [
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.checkout(function (err, co) {
+    db.put('/a', '1', function (err) {
+      t.error(err, 'no error')
+      db.put('/a', '2', function (err) {
+        t.error(err, 'no error')
+        var rs = db.createDiffStream('/a', co)
+        collect(rs, function (err, actual) {
+          t.deepEqual(actual, expected, 'diff as expected')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 tape('untracked value', function (t) {
   var db = create.one()
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,14 +1,26 @@
 var tape = require('tape')
 var create = require('./helpers/create')
 
-function collect (stream, cb) {
-  var res = []
-  stream.on('data', res.push.bind(res))
-  stream.once('error', cb)
-  stream.once('end', cb.bind(null, null, res))
-}
+tape('new value', function (t) {
+  var db = create.one()
 
-tape('basic put/get', function (t) {
+  var expected = [
+    { type: 'put', name: '/a', value: '2' }
+  ]
+
+  db.checkout(function (err, co) {
+    db.put('/a', '2', function (err) {
+      t.error(err, 'no error')
+      var rs = db.createDiffStream(co, '/a')
+      collect(rs, function (err, actual) {
+        t.deepEqual(actual, expected, 'diff as expected')
+        t.end()
+      })
+    })
+  })
+})
+
+tape('updated value', function (t) {
   var db = create.one()
 
   var expected = [
@@ -35,3 +47,10 @@ tape('basic put/get', function (t) {
     })
   })
 })
+
+function collect (stream, cb) {
+  var res = []
+  stream.on('data', res.push.bind(res))
+  stream.once('error', cb)
+  stream.once('end', cb.bind(null, null, res))
+}

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -4,9 +4,40 @@ var ram = require('random-access-memory')
 module.exports = create
 
 create.one = createOne
+create.two = createTwo
+create.three = createThree
 
 function createOne (id) {
   return hyperdb(ram, {id: id, reduce: reduce, valueEncoding: 'json'})
+}
+
+function createTwo (cb) {
+  var a = hyperdb(ram, {valueEncoding: 'json'})
+  a.ready(function () {
+    var b = hyperdb(ram, a.key, {valueEncoding: 'json'})
+    b.ready(function () {
+      a.authorize(b.local.key, function () {
+        cb(a, b)
+      })
+    })
+  })
+}
+
+function createThree (cb) {
+  var a = hyperdb(ram, {valueEncoding: 'json'})
+  a.ready(function () {
+    var b = hyperdb(ram, a.key, {valueEncoding: 'json'})
+    b.ready(function () {
+      var c = hyperdb(ram, a.key, {valueEncoding: 'json'})
+      c.ready(function () {
+        a.authorize(b.local.key, function () {
+          b.authorize(c.local.key, function () {
+            cb(a, b, c)
+          })
+        })
+      })
+    })
+  })
 }
 
 function create (id) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1,4 +1,5 @@
 var replicate = require('./helpers/replicate')
+var create = require('./helpers/create')
 var tape = require('tape')
 
 var hyperdb = require('..')
@@ -7,7 +8,7 @@ var ram = require('random-access-memory')
 tape('basic replication', function (t) {
   t.plan(6)
 
-  createTwo(function (a, b) {
+  create.two(function (a, b) {
     a.put('/a', 'a', function () {
       replicate(a, b, validate)
     })
@@ -31,7 +32,7 @@ tape('basic replication', function (t) {
 tape('2 peers, fork', function (t) {
   t.plan(20)
 
-  createTwo(function (a, b) {
+  create.two(function (a, b) {
     a.put('/root', 'root', function () {
       replicate(a, b, function () {
         a.put('/key', 'a', function () {
@@ -71,7 +72,7 @@ tape('2 peers, fork', function (t) {
 tape('2 peers, fork and non-merge write', function (t) {
   t.plan(20)
 
-  createTwo(function (a, b) {
+  create.two(function (a, b) {
     a.put('/root', 'root', function () {
       replicate(a, b, function () {
         a.put('/key', 'a', function () {
@@ -115,7 +116,7 @@ tape('2 peers, fork and non-merge write', function (t) {
 tape('2 peers, 1 reference old value', function (t) {
   t.plan(24)
 
-  createTwo(function (a, b) {
+  create.two(function (a, b) {
     a.put('/a', 'old', function () {
       replicate(a, b, function () {
         a.put('/a', 'new', function () {
@@ -163,7 +164,7 @@ tape('2 peers, 1 reference old value', function (t) {
 tape('2 peers, fork and merge write', function (t) {
   t.plan(16)
 
-  createTwo(function (a, b) {
+  create.two(function (a, b) {
     a.put('/root', 'root', function () {
       replicate(a, b, function () {
         a.put('/key', 'a', function () {
@@ -204,7 +205,7 @@ tape('2 peers, fork and merge write', function (t) {
 tape('3 peers', function (t) {
   t.plan(12)
 
-  createThree(function (a, b, c) {
+  create.three(function (a, b, c) {
     c.put('/test', 'test', function () {
       replicateThree(a, b, c, function () {
         a.get('/test', ontest)
@@ -225,7 +226,7 @@ tape('3 peers', function (t) {
 tape('3 peers + fork', function (t) {
   t.plan(18)
 
-  createThree(function (a, b, c) {
+  create.three(function (a, b, c) {
     a.put('/test', 'a', function () {
       c.put('/test', 'c', function () {
         replicateThree(a, b, c, function () {
@@ -298,35 +299,6 @@ function replicateThree (a, b, c, cb) {
     replicate(a, b, function (err) {
       if (err) return cb(err)
       replicate(b, c, cb)
-    })
-  })
-}
-
-function createTwo (cb) {
-  var a = hyperdb(ram, {valueEncoding: 'json'})
-  a.ready(function () {
-    var b = hyperdb(ram, a.key, {valueEncoding: 'json'})
-    b.ready(function () {
-      a.authorize(b.local.key, function () {
-        cb(a, b)
-      })
-    })
-  })
-}
-
-function createThree (cb) {
-  var a = hyperdb(ram, {valueEncoding: 'json'})
-  a.ready(function () {
-    var b = hyperdb(ram, a.key, {valueEncoding: 'json'})
-    b.ready(function () {
-      var c = hyperdb(ram, a.key, {valueEncoding: 'json'})
-      c.ready(function () {
-        a.authorize(b.local.key, function () {
-          b.authorize(c.local.key, function () {
-            cb(a, b, c)
-          })
-        })
-      })
     })
   })
 }


### PR DESCRIPTION
An API that lets you compare the current state of a hyperdb to an earlier state. For example:

```js
var hyperdb = require('hyperdb')
var ram = require('random-access-memory')

var db = hyperdb(ram, {valueEncoding: 'json'})

db.put('/a/foo', 'quux', function (err) {
  db.snapshot(function (err, at) {
    db.put('/a/foo', 'baz', function (err) {
      var rs = db.createDiffStream('/a', at)
      rs.on('data', console.log)
    })
  })
})
```

outputs

```js
{ type: 'del', name: '/a/foo', value: 'baz' },
{ type: 'put', name: '/a/foo', value: 'quux' }
```

You can get a diff on any key prefix, much like `db.watch()`.

This also exposes another API function, `db.snapshot()`, which captures the feedID/seq tuples at the point in time that it's called. I'm not sure whether this is the optimal way to expose this (maybe `db.put()` could return a snapshot each time?). This function is probably the least well thought out.

My motivation for this was thinking about building views or indexes on top of a hyperdb, not unlike [`hyperlog-index`](https://github.com/substack/hyperlog-index) or [`flumeview-level`](https://github.com/flumedb/flumeview-level).

This is a basic implementation, and has caveats:

1. Results are accumulated and then written to the stream after a full diff. I bet this can be done smarter and emitted in realtime.
2. All diffs are between a snapshot and HEAD (now). It would be nice if you could pass in two snapshots via an `opts` or something.
3. Live streaming would be great! Right now it's from two static, well-defined points in time.

Cheers! :tada: