### PR TITLE
API: db#createHistoryStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,12 @@ db.watch('/foo/bar', function () {
 db.put('/foo/bar/baz', 'hi') // triggers the above
 ```
 
-#### `db.snapshot(cb)`
-
-Return an object capturing the current state of `db` via the callback `cb` as
-`function (err, at)`. This object `at` can be passed into `db.createDiffStream`.
-
 #### `var stream = db.createDiffStream(key[, checkout][, head])`
 
-Find out about changes in key/value pairs between the snapshot `checkout` and
+Find out about changes in key/value pairs between the version `checkout` and
 `head` for all keys prefixed by `key`.
 
-`checkout` and `head` are snapshots to use to compare against. If not provided,
+`checkout` and `head` are versions to use to compare against. If not provided,
 `head is the current HEAD of the database, and `checkout` is the beginning of
 time.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hyperdb
 
-> Distributed scalable database.
+Distributed scalable database.
 
 ```
 npm install hyperdb

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ that occured between `checkout` and `head`. When multiple feeds conflict for the
 value of a key at a point in time, `nodes` will have multiple entries. `<node>`
 is the full hyperdb node.
 
+#### `var stream = db.createHistoryStream()
+
+Returns a readable stream of node objects covering all historic values since the
+beginning of time.
+
+Nodes are emitted in topographic order, meaning if value `v2` was aware of value
+`v1` at its insertion time, `v1` must be emitted before `v2`.
+
 #### `var stream = db.replicate([options])`
 
 Create a replication stream. Options include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hyperdb
 
-Distributed scalable database.
+> Distributed scalable database.
 
 ```
 npm install hyperdb
@@ -154,11 +154,11 @@ is the full hyperdb node.
 #### `var stream = db.createHistoryStream([opts, ][start])
 
 Returns a readable stream of node objects covering all historic values since
-either the [version](#dbversioncallback) `start`. If not specified, history is
-traversed from the beginning of time.
+either the beginning of time, or the [version](#dbversioncallback) `opts.start.
 
 Valid opts include:
 
+- `opts.start`: Use this version at the starting point for historic traversal.
 - `opts.live`: whether this is a live history stream. If so, the stream will never terminate on its own and will continue emitting nodes in real-time as they are added to the database.
 
 Nodes are emitted in topographic order, meaning if value `v2` was aware of value

--- a/README.md
+++ b/README.md
@@ -151,11 +151,15 @@ that occured between `checkout` and `head`. When multiple feeds conflict for the
 value of a key at a point in time, `nodes` will have multiple entries. `<node>`
 is the full hyperdb node.
 
-#### `var stream = db.createHistoryStream([start])
+#### `var stream = db.createHistoryStream([opts, ][start])
 
 Returns a readable stream of node objects covering all historic values since
 either the [version](#dbversioncallback) `start`. If not specified, history is
 traversed from the beginning of time.
+
+Valid opts include:
+
+- `opts.live`: whether this is a live history stream. If so, the stream will never terminate on its own and will continue emitting nodes in real-time as they are added to the database.
 
 Nodes are emitted in topographic order, meaning if value `v2` was aware of value
 `v1` at its insertion time, `v1` must be emitted before `v2`.

--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ that occured between `checkout` and `head`. When multiple feeds conflict for the
 value of a key at a point in time, `nodes` will have multiple entries. `<node>`
 is the full hyperdb node.
 
-#### `var stream = db.createHistoryStream()
+#### `var stream = db.createHistoryStream([start])
 
-Returns a readable stream of node objects covering all historic values since the
-beginning of time.
+Returns a readable stream of node objects covering all historic values since
+either the [version](#dbversioncallback) `start`. If not specified, history is
+traversed from the beginning of time.
 
 Nodes are emitted in topographic order, meaning if value `v2` was aware of value
 `v1` at its insertion time, `v1` must be emitted before `v2`.

--- a/index.js
+++ b/index.js
@@ -982,11 +982,6 @@ DB.prototype.createHistoryStream = function (opts, start) {
   if (!--pending) work()
 
   function work () {
-    if (!nodes.length) {
-      stream.push(null)
-      return
-    }
-
     var oldest = nodes.reduce(
       function (a, b) {
         if (!a && !b) return null
@@ -994,7 +989,7 @@ DB.prototype.createHistoryStream = function (opts, start) {
         else if (!b) return a
         else if (a.seq <= b.clock[a.feed]) return a
         else return b
-      })
+      }, null)
     stream.push(oldest)
 
     if (!oldest) return

--- a/index.js
+++ b/index.js
@@ -966,7 +966,6 @@ DB.prototype.createHistoryStream = function () {
 
   function get () {
     if (n >= seq.length) n = 0
-    console.log('n', n)
     if (self._writers[n].feed.length <= seq[n]) {
       n++
       return process.nextTick(get)

--- a/index.js
+++ b/index.js
@@ -929,7 +929,13 @@ DB.prototype._visitTrie = function (key, path, node, heads, halt, visited, cb, t
   }
 }
 
-DB.prototype.createHistoryStream = function (start) {
+DB.prototype.createHistoryStream = function (opts, start) {
+  if (Buffer.isBuffer(opts) && !start) {
+    start = opts
+    opts = {}
+  }
+  opts = opts || {}
+
   var stream = new Readable({objectMode: true})
   stream._read = noop
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -34,7 +34,7 @@ tape('implicit checkout', function (t) {
 tape('new value', function (t) {
   var db = create.one()
 
-  db.snapshot(function (err, co) {
+  db.version(function (err, co) {
     t.error(err, 'no error')
     db.put('/a', '2', function (err) {
       t.error(err, 'no error')
@@ -55,7 +55,7 @@ tape('new value', function (t) {
 tape('two new nodes', function (t) {
   var db = create.one()
 
-  db.snapshot(function (err, co) {
+  db.version(function (err, co) {
     t.error(err, 'no error')
     db.put('/a/foo', 'quux', function (err) {
       t.error(err, 'no error')
@@ -83,11 +83,11 @@ tape('two new nodes', function (t) {
 tape('set head', function (t) {
   var db = create.one()
 
-  db.snapshot(function (err, co1) {
+  db.version(function (err, co1) {
     t.error(err, 'no error')
     db.put('/a/foo', 'quux', function (err) {
       t.error(err, 'no error')
-      db.snapshot(function (err, co2) {
+      db.version(function (err, co2) {
         t.error(err, 'no error')
         db.put('/a/bar', 'baz', function (err) {
           t.error(err, 'no error')
@@ -112,11 +112,11 @@ tape('set head 2', function (t) {
 
   db.put('/a/foo', 'quux', function (err) {
     t.error(err, 'no error')
-    db.snapshot(function (err, co1) {
+    db.version(function (err, co1) {
       t.error(err, 'no error')
       db.put('/a/bar', 'baz', function (err) {
         t.error(err, 'no error')
-        db.snapshot(function (err, co2) {
+        db.version(function (err, co2) {
           t.error(err, 'no error')
           var rs = db.createDiffStream('/a', co1, co2)
           collect(rs, function (err, actual) {
@@ -139,7 +139,7 @@ tape('checkout === head', function (t) {
 
   db.put('/a', '2', function (err) {
     t.error(err, 'no error')
-    db.snapshot(function (err, co) {
+    db.version(function (err, co) {
       t.error(err, 'no error')
       var rs = db.createDiffStream('/a', co)
       collect(rs, function (err, actual) {
@@ -154,7 +154,7 @@ tape('checkout === head', function (t) {
 tape('new value, twice', function (t) {
   var db = create.one()
 
-  db.snapshot(function (err, co) {
+  db.version(function (err, co) {
     t.error(err, 'no error')
     db.put('/a', '1', function (err) {
       t.error(err, 'no error')
@@ -180,7 +180,7 @@ tape('untracked value', function (t) {
 
   db.put('/a', '1', function (err) {
     t.error(err, 'no error')
-    db.snapshot(function (err, co) {
+    db.version(function (err, co) {
       t.error(err, 'no error')
       db.put('/a', '2', function (err) {
         t.error(err, 'no error')
@@ -211,7 +211,7 @@ tape('diff root', function (t) {
 
   db.put('/a', '1', function (err) {
     t.error(err, 'no error')
-    db.snapshot(function (err, co) {
+    db.version(function (err, co) {
       t.error(err, 'no error')
       db.put('/a', '2', function (err) {
         t.error(err, 'no error')
@@ -246,7 +246,7 @@ tape('updated value', function (t) {
 
   db.put('/a/d/r', '1', function (err) {
     t.error(err, 'no error')
-    db.snapshot(function (err, co) {
+    db.version(function (err, co) {
       t.error(err, 'no error')
       db.put('/a/d/r', '3', function (err) {
         t.error(err, 'no error')

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -7,8 +7,8 @@ create.one = createOne
 create.two = createTwo
 create.three = createThree
 
-function createOne (id) {
-  return hyperdb(ram, {id: id, reduce: reduce, valueEncoding: 'json'})
+function createOne (key) {
+  return hyperdb(ram, key, {reduce: reduce, valueEncoding: 'json'})
 }
 
 function createTwo (cb) {

--- a/test/history.js
+++ b/test/history.js
@@ -31,6 +31,162 @@ tape('single value', function (t) {
   })
 })
 
+tape('multiple values', function (t) {
+  var db = create.one()
+
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    db.put('/b/0', 'boop', function (err) {
+      t.error(err, 'no error')
+      var rs = db.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 2)
+        t.equals(actual[0].key, '/a')
+        t.equals(actual[0].value, '2')
+        t.equals(actual[1].key, '/b/0')
+        t.equals(actual[1].value, 'boop')
+        t.end()
+      })
+    })
+  })
+})
+
+tape('multiple values: same key', function (t) {
+  var db = create.one()
+
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    db.put('/a', 'boop', function (err) {
+      t.error(err, 'no error')
+      var rs = db.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 2)
+        t.equals(actual[0].key, '/a')
+        t.equals(actual[0].value, '2')
+        t.equals(actual[1].key, '/a')
+        t.equals(actual[1].value, 'boop')
+        t.end()
+      })
+    })
+  })
+})
+
+tape('2 feeds', function (t) {
+  create.two(function (a, b) {
+    a.put('/a', 'a', function () {
+      b.put('/b', '12', function () {
+        replicate(a, b, validate)
+      })
+    })
+
+    function validate () {
+      var rs = b.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 3)
+        t.equals(actual[0].feed + ',' + actual[0].seq, '0,0')
+        t.equals(actual[1].feed + ',' + actual[1].seq, '0,1')
+        t.equals(actual[2].feed + ',' + actual[2].seq, '1,0')
+        t.end()
+      })
+    }
+  })
+})
+
+tape('2 feeds: clock conflict', function (t) {
+  create.two(function (a, b) {
+    a.put('/a', 'a', function () {
+      b.put('/a', 'b', function () {
+        replicate(a, b, function () {
+          a.put('/a', 'c', function () {
+            replicate(a, b, function () {
+              validate()
+            })
+          })
+        })
+      })
+    })
+
+    function validate () {
+      var rs = a.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 4)
+        t.equals(actual[0].feed + ',' + actual[0].seq, '0,0')
+        t.equals(actual[1].feed + ',' + actual[1].seq, '0,1')
+        t.equals(actual[2].feed + ',' + actual[2].seq, '1,0')
+        t.equals(actual[3].feed + ',' + actual[3].seq, '0,2')
+        t.end()
+      })
+    }
+  })
+})
+
+tape('3 feeds', function (t) {
+  create.three(function (a, b, c) {
+    a.put('/a', 'a', function () {
+      b.put('/a', 'b', function () {
+        c.put('/a', 'c', function () {
+          replicate(a, b, function () {
+            replicate(a, c, function () {
+              validate()
+            })
+          })
+        })
+      })
+    })
+
+    function validate () {
+      var rs = a.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 5)
+        t.equals(actual[0].feed + ',' + actual[0].seq, '0,0')
+        t.equals(actual[1].feed + ',' + actual[1].seq, '0,1')
+        t.equals(actual[2].feed + ',' + actual[2].seq, '1,0')
+        t.equals(actual[3].feed + ',' + actual[3].seq, '1,1')
+        t.equals(actual[4].feed + ',' + actual[4].seq, '2,0')
+        t.end()
+      })
+    }
+  })
+})
+
+tape('3 feeds: clock conflict', function (t) {
+  create.three(function (a, b, c) {
+    a.put('/a', 'a', function () {
+      b.put('/a', 'b', function () {
+        replicate(a, b, function () {
+          c.put('/a', 'c', function () {
+            replicate(a, c, function () {
+              c.put('/a', 'd', function () {
+                validate()
+              })
+            })
+          })
+        })
+      })
+    })
+
+    function validate () {
+      var rs = c.createHistoryStream()
+      collect(rs, function (err, actual) {
+        t.error(err, 'no error')
+        t.equals(actual.length, 6)
+        t.equals(actual[0].feed + ',' + actual[0].seq, '0,0')  // a
+        t.equals(actual[1].feed + ',' + actual[1].seq, '0,1')  // a
+        t.equals(actual[2].feed + ',' + actual[2].seq, '1,0')  // c
+        t.equals(actual[3].feed + ',' + actual[3].seq, '2,0')  // b
+        t.equals(actual[4].feed + ',' + actual[4].seq, '2,1')  // b
+        t.equals(actual[5].feed + ',' + actual[5].seq, '1,1')  // c
+        t.end()
+      })
+    }
+  })
+})
+
 function collect (stream, cb) {
   var res = []
   stream.on('data', res.push.bind(res))

--- a/test/history.js
+++ b/test/history.js
@@ -1,0 +1,39 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+var replicate = require('./helpers/replicate')
+
+tape('empty history', function (t) {
+  var db = create.one()
+
+  var expected = []
+
+  var rs = db.createHistoryStream()
+  collect(rs, function (err, actual) {
+    t.error(err, 'no error')
+    t.deepEqual(actual, expected, 'diff as expected')
+    t.end()
+  })
+})
+
+tape('single value', function (t) {
+  var db = create.one()
+
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    var rs = db.createHistoryStream()
+    collect(rs, function (err, actual) {
+      t.error(err, 'no error')
+      t.equals(actual.length, 1)
+      t.equals(actual[0].key, '/a')
+      t.equals(actual[0].value, '2')
+      t.end()
+    })
+  })
+})
+
+function collect (stream, cb) {
+  var res = []
+  stream.on('data', res.push.bind(res))
+  stream.once('error', cb)
+  stream.once('end', cb.bind(null, null, res))
+}

--- a/test/history.js
+++ b/test/history.js
@@ -321,6 +321,32 @@ tape('3 feeds: start version', function (t) {
   })
 })
 
+tape('live stream: 1 feed, 1 value', function (t) {
+  var db = create.one()
+
+  t.plan(6)
+
+  var n = 2
+
+  var hs = db.createHistoryStream({live: true})
+  db.put('/a', '2', function (err) {
+    t.error(err, 'no error')
+    db.put('/foo/bar', 'quux', function (err) {
+      t.error(err, 'no error')
+      hs.on('data', function (node) {
+        n--
+        if (n === 1) {
+          t.equals(node.key, '/a')
+          t.equals(node.value, '2')
+        } else if (n === 0) {
+          t.equals(node.key, '/foo/bar')
+          t.equals(node.value, 'quux')
+        }
+      })
+    })
+  })
+})
+
 function collect (stream, cb) {
   var res = []
   stream.on('data', res.push.bind(res))


### PR DESCRIPTION
Implements a `createHistoryStream` API. Nodes are produced from a readable stream in topographic sequence. That is, all nodes that a node is aware of via its `clock` are emitted before that node.