### PR TITLE
db.createWriteStream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Insert a batch of values efficiently, in a single atomic transaction. A batch sh
 }
 ```
 
+#### `var stream = db.createWriteStream()`
+
+Create a writable stream.
+
+Where `stream.write(data)` accepts data as an object or an array of objects with the same form as `db.batch()`.
+
 #### `db.get(key, callback)`
 
 Lookup a string `key`. Returns a nodes array with the current values for this key.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "array-lru": "^1.1.1",
+    "bulk-write-stream": "^1.1.3",
     "codecs": "^1.2.0",
     "hypercore": "^6.9.0",
     "hypercore-protocol": "^6.4.0",

--- a/test/basic.js
+++ b/test/basic.js
@@ -271,3 +271,40 @@ tape('batch', function (t) {
     })
   }
 })
+
+tape('createWriteStream', function (t) {
+  t.plan(10)
+  var db = create.one()
+  var writer = db.createWriteStream()
+
+  writer.write([{
+    type: 'put',
+    key: 'foo',
+    value: 'foo'
+  }, {
+    type: 'put',
+    key: 'bar',
+    value: 'bar'
+  }])
+
+  writer.write({
+    type: 'put',
+    key: 'baz',
+    value: 'baz'
+  })
+
+  writer.end(function (err) {
+    t.error(err, 'no error')
+    same('foo', 'foo')
+    same('bar', 'bar')
+    same('baz', 'baz')
+  })
+
+  function same (key, val) {
+    db.get(key, function (err, node) {
+      t.error(err, 'no error')
+      t.same(node.key, key)
+      t.same(node.value, val)
+    })
+  }
+})


### PR DESCRIPTION
Hey @mafintosh and @noffle, this PR adds a simple interface for creating a writable stream. It simply pushes the data into the db's batch method. I have made it so that the it accepts both objects and arrays of objects. This adds a bit of complexity, but also adds flexibility so that we can write batches to the stream.

Let me know your thoughts.