### PR TITLE
createReadStream()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,1 @@
+{ "extends": ["standard"] }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Insert a batch of values efficiently, in a single atomic transaction. A batch sh
 }
 ```
 
+#### `var stream = db.createReadStream([prefix])`
+
+Create a readable stream. Returns all nodes that match the prefix in order from newest to oldest.
+
 #### `var stream = db.createWriteStream()`
 
 Create a writable stream.

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var events = require('events')
 var inherits = require('inherits')
 var toBuffer = require('to-buffer')
 var varint = require('varint')
-var Readable = require('stream').Readable
+var Readable = require('readable-stream').Readable
 var bulk = require('bulk-write-stream')
 var LRU = require('lru')
 var once = require('once')
@@ -786,6 +786,7 @@ DB.prototype.createReadStream = function (key, opts) {
   return stream
 
   function read () {
+    if (stream.destroyed) return
     // if no heads - get heads and process first tries
     if (!streamQueue) {
       self.heads(function (err, heads) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "hypercore": "^6.9.0",
     "hypercore-protocol": "^6.4.0",
     "inherits": "^2.0.3",
+    "lru": "^3.1.0",
     "mutexify": "^1.1.0",
     "once": "^1.4.0",
     "protocol-buffers": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "once": "^1.4.0",
     "protocol-buffers": "^3.2.1",
     "random-access-file": "^1.8.1",
+    "readable-stream": "^2.3.3",
     "sodium-universal": "^1.4.0",
     "thunky": "^1.0.2",
     "to-buffer": "^1.1.0",

--- a/test/helpers/populate.js
+++ b/test/helpers/populate.js
@@ -1,0 +1,15 @@
+module.exports = populate
+
+function promisedPut (db, key, val) {
+  return new Promise((resolve, reject) => db.put(key, val, (e) => {
+    if (e) return reject(e)
+    resolve()
+  }))
+}
+
+function populate (db, vals, offset, cb) {
+  var promised = vals.reduce((p, v, i) => {
+    return p.then(() => promisedPut(db, v, (offset || 0) + i))
+  }, Promise.resolve())
+  promised.then(cb).catch(e => cb(e))
+}

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -85,7 +85,7 @@ tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   })
 })
 
-tape.only('readStream with two feeds', { timeout: 1000 }, function (t) {
+tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     populate(a, ['a/a', 'a/b', 'a/c'], 0, (err) => {
       t.error(err)

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -2,21 +2,30 @@ var tape = require('tape')
 var create = require('./helpers/create')
 var replicate = require('./helpers/replicate')
 
+function promisedPut (db, key, val) {
+  return new Promise((resolve, reject) => db.put(key, val, (e) => {
+    if (e) return reject(e)
+    resolve()
+  }))
+}
+
 function populate (db, vals, offset, cb) {
-  var writer = db.createWriteStream()
+  var promised = vals.reduce((p, v, i) => {
+    return p.then(() => promisedPut(db, v, (offset || 0) + i))
+  }, Promise.resolve())
+  promised.then(cb).catch(e => cb(e))
+  // There appears to be a issue with writeStream.
+  // var writer = db.createWriteStream()
   // writer.write(vals.map((v, i) => ({
   //   type: 'put',
   //   key: v,
   //   value: (offset || 0) + i
   // })))
-  vals.forEach((v, i) => writer.write({
-    type: 'put',
-    key: v,
-    value: (offset || 0) + i
-  }))
-  writer.end((err) => {
-    cb(err)
-  })
+  // // setTimeout(() => {
+  // writer.end((err) => {
+  //   cb(err)
+  // })
+  // // }, 200)
 }
 
 tape('basic readStream', { timeout: 1000 }, function (t) {
@@ -53,20 +62,24 @@ tape('basic readStream', { timeout: 1000 }, function (t) {
 tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     var aValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
+    var bValues = ['a/b', 'a/b/c', 'b/c/d', 'b/c']
     populate(a, aValues, 0, (err) => {
       t.error(err, 'no error')
       replicate(a, b, () => {
-        var bValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
-        populate(b, bValues, 4, validate)
+        populate(b, bValues, 4, (err) => {
+          t.error(err, 'no error')
+          replicate(a, b, validate)
+        })
       })
     })
     function validate (err) {
       t.error(err, 'no error')
-      var reader = b.createReadStream('b/')
+      var reader = a.createReadStream('b/')
       var expectedValues = [7, 6]
-      reader.on('data', (data) => {
-        // console.log('data---', data.key, data.value)
-        t.equals(data.value, expectedValues.shift())
+      reader.on('data', (nodes) => {
+        // console.log('data---', nodes[0].key, nodes.map(v => v.value))
+        t.equals(nodes.length, 1)
+        t.equals(nodes[0].value, expectedValues.shift())
       })
       reader.on('end', () => {
         t.ok(expectedValues.length === 0)
@@ -93,17 +106,57 @@ tape('readStream with two feeds (again)', { timeout: 1000 }, function (t) {
       })
     })
     function validate () {
-      const reader = a.createReadStream('')
-      let previousValue = 10000
-      let total = 0
-      reader.on('data', (data) => {
-        // console.log('data ->', data.key, typeof data.value, data.value)
-        t.ok(previousValue > data.value)
-        previousValue = data.value
+      var reader = b.createReadStream('/')
+      var previousValue = 10000
+      var total = 0
+      reader.on('data', (nodes) => {
+        // console.log('data ->', nodes.map(n => n.key + ' ' + n.value))
+        t.ok(previousValue > nodes[nodes.length - 1].value)
+        previousValue = nodes[nodes.length - 1].value
         total++
       })
       reader.on('end', () => {
         t.equals(total, 6)
+        t.pass('stream ended ok')
+        t.end()
+      })
+      reader.on('error', (err) => {
+        t.fail(err.message)
+        t.end()
+      })
+    }
+  })
+})
+
+tape('readStream with conflicting feeds', { timeout: 2000 }, function (t) {
+  var conflictingKeys = ['/c/a', '/c/b', '/c/c', '/c/d']
+  var expectedKeys = ['/a/a', '/a/b', '/a/c', '/b/a', '/b/b', '/b/c', '/c/b', '/c/c', '/c/a', '/c/d'].reverse()
+  create.two((a, b) => {
+    populate(a, ['/a/a', '/a/b', '/a/c'], 0, (err) => {
+      t.error(err)
+      replicate(a, b, () => {
+        populate(b, ['/b/a', '/b/b', '/b/c'], 3, (err) => {
+          t.error(err)
+          replicate(a, b, (err) => {
+            t.error(err)
+            populate(a, conflictingKeys, 6, (err) => {
+              t.error(err)
+              populate(b, conflictingKeys.reverse(), 6 + conflictingKeys.length, (err) => {
+                t.error(err)
+                replicate(a, b, validate)
+              })
+            })
+          })
+        })
+      })
+    })
+    function validate () {
+      var reader = a.createReadStream('/')
+      reader.on('data', (data) => {
+        // console.log(data[0].key, data.map((d) => `${d.feed},${d.clock.reduce((p, v) => p + v, d.seq)}:${d.value}`))
+        t.same(data[0].key, expectedKeys.shift())
+      })
+      reader.on('end', () => {
         t.pass('stream ended ok')
         t.end()
       })

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -2,35 +2,46 @@ var tape = require('tape')
 var create = require('./helpers/create')
 var replicate = require('./helpers/replicate')
 
-tape('basic readStream', { timeout: 1000 }, function (t) {
-  // t.plan(2)
-  var db = create.one()
+function populate (db, vals, offset, cb) {
   var writer = db.createWriteStream()
-  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // var vals = ['a/b', 'a/c']
-  writer.write(vals.map((v, i) => ({
+  // writer.write(vals.map((v, i) => ({
+  //   type: 'put',
+  //   key: v,
+  //   value: (offset || 0) + i
+  // })))
+  vals.forEach((v, i) => writer.write({
     type: 'put',
     key: v,
-    value: i
-  })))
-
+    value: (offset || 0) + i
+  }))
   writer.end((err) => {
+    cb(err)
+  })
+}
+
+tape('basic readStream', { timeout: 1000 }, function (t) {
+  var db = create.one()
+  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
+  // var vals = ['foo/bar', 'c', 'bar/dog', 'bar/cat', 'bar/foo', 'bar/cat']
+  // var vals = ['foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  populate(db, vals, 0, validate)
+
+  function validate (err) {
     t.error(err, 'no error')
-    db.get('bar/cat', (err, node) => {
-      t.error(err, 'no error')
-      console.log('node:::', node)
-    })
     var reader = db.createReadStream('bar/')
+    var catCount = 0
     reader.on('data', (data) => {
-      console.log('data,', data.key, '----', data.value)
+      if (data.key === 'bar/cat') catCount++
+      // console.log('data,', data.key, '----', data.value)
     })
     reader.on('end', () => {
+      t.equals(catCount, Math.pow(2, 1))
       t.pass('stream ended ok')
       t.end()
     })
@@ -39,53 +50,42 @@ tape('basic readStream', { timeout: 1000 }, function (t) {
       t.fail(err.message)
       t.end()
     })
-  })
+  }
 })
 
 tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     var aValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
-    var aWriter = a.createWriteStream()
-    aWriter.write(aValues.map((v, i) => ({
-      type: 'put',
-      key: v,
-      value: i
-    })))
-    aWriter.end((err) => {
+    populate(a, aValues, 0, (err) => {
       t.error(err, 'no error')
-      replicate(a, b, writeToB)
+      replicate(a, b, () => {
+        var bValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
+        populate(b, bValues, 4, validate)
+      })
     })
-    function writeToB () {
-      var bValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
-      var bWriter = b.createWriteStream()
-      bWriter.write(bValues.map((v, i) => ({
-        type: 'put',
-        key: v,
-        value: 4 + i
-      })))
-      bWriter.end((err) => {
-        t.error(err, 'no error')
-        var reader = b.createReadStream('b/')
-        var expectedValues = [7, 6, 2, 3]
-        reader.on('data', (data) => {
-          t.equals(data.value, expectedValues.shift())
-        })
-        reader.on('end', () => {
-          t.ok(expectedValues.length === 0)
-          t.pass('stream ended ok')
-          t.end()
-        })
-        reader.on('error', (err) => {
-          console.log('Something went wrong', err)
-          t.fail(err.message)
-          t.end()
-        })
+    function validate (err) {
+      t.error(err, 'no error')
+      var reader = b.createReadStream('b/')
+      var expectedValues = [7, 6, 3, 2]
+      reader.on('data', (data) => {
+        // console.log('data---', data.key, data.value)
+        t.equals(data.value, expectedValues.shift())
+      })
+      reader.on('end', () => {
+        t.ok(expectedValues.length === 0)
+        t.pass('stream ended ok')
+        t.end()
+      })
+      reader.on('error', (err) => {
+        console.log('Something went wrong', err)
+        t.fail(err.message)
+        t.end()
       })
     }
   })
 })
 
-tape('readStream with two feeds', { timeout: 1000 }, function (t) {
+tape('readStream with two feeds (again)', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     populate(a, ['a/a', 'a/b', 'a/c'], 0, (err) => {
       t.error(err)
@@ -114,15 +114,3 @@ tape('readStream with two feeds', { timeout: 1000 }, function (t) {
     }
   })
 })
-
-function populate (db, vals, offset, cb) {
-  var writer = db.createWriteStream()
-  writer.write(vals.map((v, i) => ({
-    type: 'put',
-    key: v,
-    value: (offset || 0) + i
-  })))
-  writer.end((err) => {
-    cb(err)
-  })
-}

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -1,0 +1,82 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+var replicate = require('./helpers/replicate')
+
+tape('basic readStream', { timeout: 1000 }, function (t) {
+  // t.plan(2)
+  var db = create.one()
+  var writer = db.createWriteStream()
+  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat', 'aa', 'bb', 'c']
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
+  // var vals = ['a/b', 'a/c']
+  writer.write(vals.map((v, i) => ({
+    type: 'put',
+    key: v,
+    value: i
+  })))
+
+  writer.end((err) => {
+    t.error(err, 'no error')
+    var reader = db.createReadStream('bar/')
+    reader.on('data', (data) => {
+      console.log('data,', data.key, '----', data.value)
+    })
+    reader.on('end', () => {
+      t.pass('stream ended ok')
+      t.end()
+    })
+    reader.on('error', (err) => {
+      console.log('Something went wrong', err)
+      t.fail(err.message)
+      t.end()
+    })
+  })
+})
+
+tape.only('readStream with two feeds', { timeout: 1000 }, function (t) {
+  create.two((a, b) => {
+    var aValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
+    var aWriter = a.createWriteStream()
+    aWriter.write(aValues.map((v, i) => ({
+      type: 'put',
+      key: v,
+      value: i
+    })))
+    aWriter.end((err) => {
+      t.error(err, 'no error')
+      replicate(a, b, writeToB)
+    })
+    function writeToB () {
+      var bValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
+      var bWriter = b.createWriteStream()
+      bWriter.write(bValues.map((v, i) => ({
+        type: 'put',
+        key: v,
+        value: 4 + i
+      })))
+      bWriter.end((err) => {
+        t.error(err, 'no error')
+        var reader = b.createReadStream('b/')
+        var expectedValues = [7, 6, 2, 3]
+        reader.on('data', (data) => {
+          t.equals(data.value, expectedValues.shift())
+        })
+        reader.on('end', () => {
+          t.ok(expectedValues.length === 0)
+          t.pass('stream ended ok')
+          t.end()
+        })
+        reader.on('error', (err) => {
+          console.log('Something went wrong', err)
+          t.fail(err.message)
+          t.end()
+        })
+      })
+    }
+  })
+})

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -6,9 +6,9 @@ tape('basic readStream', { timeout: 1000 }, function (t) {
   // t.plan(2)
   var db = create.one()
   var writer = db.createWriteStream()
-  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat', 'aa', 'bb', 'c']
-  vals = vals.concat(vals)
-  vals = vals.concat(vals)
+  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
+  // vals = vals.concat(vals)
+  // vals = vals.concat(vals)
   // vals = vals.concat(vals)
   // vals = vals.concat(vals)
   // vals = vals.concat(vals)
@@ -38,7 +38,7 @@ tape('basic readStream', { timeout: 1000 }, function (t) {
   })
 })
 
-tape.only('readStream with two feeds', { timeout: 1000 }, function (t) {
+tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     var aValues = ['a/b', 'a/b/c', 'b/c', 'b/c/d']
     var aWriter = a.createWriteStream()

--- a/test/readStream.js
+++ b/test/readStream.js
@@ -21,27 +21,25 @@ function populate (db, vals, offset, cb) {
 
 tape('basic readStream', { timeout: 1000 }, function (t) {
   var db = create.one()
-  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
-  // var vals = ['foo/bar', 'c', 'bar/dog', 'bar/cat', 'bar/foo', 'bar/cat']
-  // var vals = ['foo/b', 'bar/cat', 'foo/bar', 'bar/cat']
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
-  // vals = vals.concat(vals)
+  var vals = ['foo', 'foo/a', 'foo/b', 'aa', 'bb', 'c', 'bar/baz', 'foo/abc', 'foo/b', 'bar/cat', 'foo/bar', 'bar/cat', 'something']
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
+  vals = vals.concat(vals)
   populate(db, vals, 0, validate)
 
   function validate (err) {
     t.error(err, 'no error')
-    var reader = db.createReadStream('bar/')
-    var catCount = 0
+    var reader = db.createReadStream('foo/')
+    var fooCount = 0
     reader.on('data', (data) => {
-      if (data.key === 'bar/cat') catCount++
+      if (data.key === 'foo/b') fooCount++
       // console.log('data,', data.key, '----', data.value)
     })
     reader.on('end', () => {
-      t.equals(catCount, Math.pow(2, 1))
+      t.equals(fooCount, 1)
       t.pass('stream ended ok')
       t.end()
     })
@@ -66,7 +64,6 @@ tape('readStream with two feeds', { timeout: 1000 }, function (t) {
     function validate (err) {
       t.error(err, 'no error')
       var reader = b.createReadStream('b/')
-      var expectedValues = [7, 6, 3, 2]
       reader.on('data', (data) => {
         // console.log('data---', data.key, data.value)
         t.equals(data.value, expectedValues.shift())
@@ -77,7 +74,6 @@ tape('readStream with two feeds', { timeout: 1000 }, function (t) {
         t.end()
       })
       reader.on('error', (err) => {
-        console.log('Something went wrong', err)
         t.fail(err.message)
         t.end()
       })
@@ -87,27 +83,21 @@ tape('readStream with two feeds', { timeout: 1000 }, function (t) {
 
 tape('readStream with two feeds (again)', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
-    populate(a, ['a/a', 'a/b', 'a/c'], 0, (err) => {
       t.error(err)
       replicate(a, b, () => {
-        populate(b, ['b/a', 'b/b', 'b/c', 'a/a', 'a/b', 'a/c'], 3, (err) => {
           t.error(err)
           replicate(a, b, validate)
         })
       })
     })
     function validate () {
-      const reader = b.createReadStream('/')
       reader.on('data', (data) => {
-        console.log('data ->', data.key, data.value)
       })
       reader.on('end', () => {
-        // t.ok(expectedValues.length === 0)
         t.pass('stream ended ok')
         t.end()
       })
       reader.on('error', (err) => {
-        // console.log('Something went wrong', err)
         t.fail(err.message)
         t.end()
       })


### PR DESCRIPTION
Hey @mafintosh @noffle,

I started playing around with building a readable stream interface for hyperdb. I started this as createDiffStream is scaling badly, and wanted to see if I could get a super lean stream working. 

This is really rough, and not alt all ready for merging (still using => funcs and riddled with console logs), but I figured I should open a PR to get your guys input. I have been using @noffle's  architecture description as a basis, and reading your code, but still might be doing something totally stupid.

Any thoughts would be appreciated. Its quick and respects back pressure so hopefully will scale well. 

<strike>One bug that I cant seem to figure out so far is illustrated in the first test - although there are multiple 'bar/cat' keys, it's only returning the latest - while for all other keys (for example`foo/`) the duplicates are returned.</strike> UPDATE: I changed the implementation of read stream so that it only returns the latest entries. 
  