### PR TITLE
update protocol-buffers to ^4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "inherits": "^2.0.3",
     "mutexify": "^1.1.0",
     "once": "^1.4.0",
-    "protocol-buffers": "^3.2.1",
+    "protocol-buffers": "^4.0.2",
     "random-access-file": "^1.8.1",
     "sodium-universal": "^1.4.0",
     "thunky": "^1.0.2",


### PR DESCRIPTION
This pr updates the dependency on `protocol-buffers` to ^4.0.2

The newest `protocol-buffers` version doesn't depend on `brfs@1.43`, which ultimately depends on [a vulnerable version of `static-eval` (@0.2.4) ](https://snyk.io/vuln/npm:static-eval:20171016).

ps: There's also [a pr on `brfs`](https://github.com/browserify/brfs/pull/84) to update it's dependencies.

---
full depencency graph:
`hyperdb@2.0.0 › protocol-buffers@3.2.1 › brfs@1.4.3 › static-module@1.5.0 › static-eval@0.2.4`