### PR TITLE
Fix race condition with history stream on auth'd feed

### DIFF
--- a/test/history.js
+++ b/test/history.js
@@ -484,6 +484,21 @@ tape('2 feeds: live + 3rd feed added', function (t) {
   })
 })
 
+tape('start live history stream on auth\'d feed before put', function (t) {
+  t.plan(1)
+
+  create.two(function (a, b) {
+    var rs = b.createHistoryStream({start: undefined, live: true})
+    var expected = 1
+    rs.on('data', function (node) {
+      if (--expected < 0) t.fail()
+      else t.equals(node.feed + ',' + node.seq, '1,0')
+    })
+
+    b.put('/b', '12')
+  })
+})
+
 function collect (stream, cb) {
   var res = []
   stream.on('data', res.push.bind(res))


### PR DESCRIPTION
This addresses the following situation:

1. A hyperdb is created (A); it authorizes a new feed (B)
2. A live history stream is created on B (no entries written yet) *and* B writes its first entry
3. The `writer` event will fire first
4. The `writer` event handler in `createHistoryStream` turns off event listeners and does an async call to lookup the new head node
5. During this async period `append` fires, but is lost because step 4 turned it off
6. The history stream hangs indefinitely, waiting for an `append` event that never comes