### PR TITLE
Mutate copy of heads in _visitGet

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,8 +425,10 @@ DB.prototype._get = function (key, wait, result, visit, cb) {
     var missing = heads.length
     var error = null
 
+    var headsCopy = heads.slice()
+
     for (var i = 0; i < heads.length; i++) {
-      self._visitGet(key, path, 0, heads[i], heads, result, visit, onget)
+      self._visitGet(key, path, 0, heads[i], headsCopy, result, visit, onget)
     }
 
     function onget (err) {

--- a/test/checkout.js
+++ b/test/checkout.js
@@ -27,3 +27,31 @@ tape('basic checkout', function (t) {
     })
   })
 })
+
+tape('checkout gets should pass for all keys inserted before checkout seq', function (t) {
+  t.plan(7)
+
+  var db1 = create.one()
+  db1.put('a', 'b', function (err) {
+    t.error(err)
+    db1.put('c', 'd', function (err) {
+      t.error(err)
+      checkoutAndTest()
+    })
+  })
+
+  function checkoutAndTest () {
+    db1.version(function (err, version) {
+      t.error(err)
+      var db2 = db1.checkout(version)
+      db2.get('a', function (err, nodes) {
+        t.error(err)
+        t.same(nodes[0].value, 'b') // This passes.
+        db2.get('c', function (err, nodes) {
+          t.error(err)
+          t.same(nodes[0].value, 'd') // This fails.
+        })
+      })
+    })
+  }
+})

--- a/test/checkout.js
+++ b/test/checkout.js
@@ -46,10 +46,10 @@ tape('checkout gets should pass for all keys inserted before checkout seq', func
       var db2 = db1.checkout(version)
       db2.get('a', function (err, nodes) {
         t.error(err)
-        t.same(nodes[0].value, 'b') // This passes.
+        t.same(nodes[0].value, 'b')
         db2.get('c', function (err, nodes) {
           t.error(err)
-          t.same(nodes[0].value, 'd') // This fails.
+          t.same(nodes[0].value, 'd')
         })
       })
     })


### PR DESCRIPTION
Turns out that #52 was being caused by `_visitGet` directly mutating `this._heads` instead of mutating a copy. There might be a better fix for this, but copying `this._heads` here does appear to resolve the issue.

PR includes an additional test case.