### PR TITLE
add failing test case for createReadStream

### DIFF
--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -36,6 +36,31 @@ tape('basic readStream', { timeout: 1000 }, function (t) {
   }
 })
 
+tape('basic readStream (again)', { timeout: 1000 }, function (t) {
+  var db = create.one()
+  var vals = ['foo/a', 'foo/abc', 'foo/a/b']
+  var expected = ['foo/a', 'foo/a/b']
+  put(db, vals, validate)
+
+  function validate (err) {
+    t.error(err, 'no error')
+    var reader = db.createReadStream('foo/a')
+    reader.on('data', (data) => {
+      var index = expected.indexOf(data.key)
+      t.ok(index !== -1, 'key is expected')
+      if (index >= 0) expected.splice(index, 1)
+    })
+    reader.on('end', () => {
+      t.equals(expected.length, 0)
+      t.end()
+    })
+    reader.on('error', (err) => {
+      t.fail(err.message)
+      t.end()
+    })
+  }
+})
+
 tape('readStream with two feeds', { timeout: 1000 }, function (t) {
   create.two((a, b) => {
     var aValues = ['b/a', 'a/b/c', 'b/c', 'b/c/d'].map(toKeyValuePairs('A'))


### PR DESCRIPTION
This is a test checking if createReadStream returns key/values exactly matching the prefix.
I am not sure if this is expected behaviour or not? Although as a user my assumption is that when creating a read stream for a key, the stream would return its own value too if present.