### PR TITLE
[WIP] add option for sorting iterator by the last added to the db.

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -19,6 +19,7 @@ function Iterator (db, prefix, opts) {
   this._start = 0
   this._updated = false
   this._gt = !!opts.gt
+  this._sortOrder = opts.latest ? 'latest' : 'hash'
   this._map = options.map(opts, db)
   this._reduce = options.reduce(opts, db)
 }
@@ -91,7 +92,7 @@ Iterator.prototype._consume = function (cb) {
     return
   }
 
-  var min = minKey(this._workers)
+  var min = minKey(this._workers, this._sortOrder)
   var nodes = []
 
   for (var i = 0; i < this._workers.length; i++) {
@@ -202,10 +203,42 @@ function allSkips (stack, iterator, worker) {
   return stack.every(t => !iterator._isHead(t.node, worker))
 }
 
+function sortNodesByClock (a, b) {
+  var isGreater = false
+  var isLess = false
+  var length = a.clock.length
+  if (b.clock.length > length) length = b.clock.length
+  for (var i = 0; i < length; i++) {
+    var diff = (a.clock[i] || 0) - (b.clock[i] || 0)
+    if (diff > 0) isGreater = true
+    if (diff < 0) isLess = true
+  }
+  if (isGreater && isLess) return 0
+  if (isLess) return -1
+  if (isGreater) return 1
+  return 0
+}
+
+function sortStackByClockAndSeq (a, b) {
+  a = a.node || a.value
+  b = b.node || b.value
+  var sortValue = sortNodesByClock(a, b)
+  // console.log('queue', sortValue, a.seq+'/'+ a.feed, 'vs', b.seq+'/'+ b.feed)
+  if (sortValue !== 0) return sortValue
+  // // same time, so use sequence to order
+  if (a.feed === b.feed) return a.seq - b.seq
+  var bOffset = b.clock.reduce((p, v) => p + v, b.seq)
+  var aOffset = a.clock.reduce((p, v) => p + v, a.seq)
+  // if real sequence is the same then return sort on feed
+  if (bOffset === aOffset) return b.feed - a.feed
+  return aOffset - bOffset
+}
+
 function pop (iterator, worker) {
   while (true) {
     var len = worker.stack.length
     if (len) {
+      if (iterator._sortOrder === 'latest') worker.stack.sort(sortStackByClockAndSeq)
       var top = worker.stack.pop()
       if (top.node && !iterator._isHead(top.node, worker)) {
         if (!allSkips(worker.stack, iterator, worker)) {
@@ -336,13 +369,18 @@ function nextNT (iterator, worker, cb) {
   process.nextTick(next, iterator, worker, cb)
 }
 
-function minKey (workers) {
+function hashSort (a, b) {
+  return sortKey(b.value).localeCompare(sortKey(a.value))
+}
+
+function minKey (workers, sortOrder) {
   var min = null
+  var sortFn = sortOrder === 'hash' ? hashSort : sortStackByClockAndSeq
   for (var i = 0; i < workers.length; i++) {
     var t = workers[i]
     if (!min || !min.value) min = t
     if (!t.value) continue
-    if (sortKey(t.value).localeCompare(sortKey(min.value)) < 0) {
+    if (sortFn(t, min) >= 0) {
       min = t
     }
   }

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -19,7 +19,7 @@ function Iterator (db, prefix, opts) {
   this._start = 0
   this._updated = false
   this._gt = !!opts.gt
-  this._sortOrder = opts.latest ? 'latest' : 'hash'
+  this._sortLatest = !!opts.latest
   this._map = options.map(opts, db)
   this._reduce = options.reduce(opts, db)
 }
@@ -92,7 +92,7 @@ Iterator.prototype._consume = function (cb) {
     return
   }
 
-  var min = minKey(this._workers, this._sortOrder)
+  var min = minKey(this._workers, this._sortLatest)
   var nodes = []
 
   for (var i = 0; i < this._workers.length; i++) {
@@ -239,7 +239,7 @@ function pop (iterator, worker) {
   while (true) {
     var len = worker.stack.length
     if (len) {
-      if (iterator._sortOrder === 'latest') worker.stack.sort(sortStackByClockAndSeq)
+      if (iterator._sortLatest) worker.stack.sort(sortStackByClockAndSeq)
       var top = worker.stack.pop()
       if (top.node && !iterator._isHead(top.node, worker)) {
         if (!allSkips(worker.stack, iterator, worker)) {
@@ -374,9 +374,9 @@ function hashSort (a, b) {
   return sortKey(b.value).localeCompare(sortKey(a.value))
 }
 
-function minKey (workers, sortOrder) {
+function minKey (workers, sortLatest) {
   var min = null
-  var sortFn = sortOrder === 'hash' ? hashSort : sortStackByClockAndSeq
+  var sortFn = sortLatest ? sortStackByClockAndSeq : hashSort
   for (var i = 0; i < workers.length; i++) {
     var t = workers[i]
     if (!min || !min.value) min = t

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -222,8 +222,9 @@ function sortNodesByClock (a, b) {
 function sortStackByClockAndSeq (a, b) {
   a = a.node || a.value
   b = b.node || b.value
+  if (a && !b) return 1
+  if (b && !a) return 1
   var sortValue = sortNodesByClock(a, b)
-  // console.log('queue', sortValue, a.seq+'/'+ a.feed, 'vs', b.seq+'/'+ b.feed)
   if (sortValue !== 0) return sortValue
   // // same time, so use sequence to order
   if (a.feed === b.feed) return a.seq - b.seq

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -115,7 +115,7 @@ Iterator.prototype._fork = function (nodes, from, offset) {
   }
 
   for (var i = 0; i < nodes.length; i++) {
-    var w = new Worker(nodes[i], offset, from)
+    var w = new Worker(nodes[i], offset, from, this._sortLatest)
     this._workers.push(w)
     this._updated = true
     if (!this._isHead(w.lock, w)) this._endWorker(w, true)
@@ -164,18 +164,56 @@ Iterator.prototype._isHead = function (head, worker) {
   return true
 }
 
-function Worker (head, i, from) {
+function Worker (head, i, from, sortLatest) {
+  this.id = Math.random().toString(36).substring(7)
   this.lock = head
   this.value = null
   this.forks = 0
   this.ended = false
   this.stack = []
+  this.pendingStack = []
   this.pending = 0
   this.error = null
   this.callback = null
   this.from = from
+  this.sorted = true
+  this.unfinished = null
+  this.sortLatest = !!sortLatest
 
   this.stack.push({node: head, i, fork: null})
+}
+
+Worker.prototype.sort = function () {
+  if (this.pendingStack.length) this.addPendingToStack()
+  if (this.sortLatest && !this.sorted) {
+    this.stack.sort(sortStackByClockAndSeq)
+    this.sorted = true
+  }
+
+  if (this.unfinished) {
+    this.stack.push(this.unfinished)
+    this.unfinished = null
+  }
+}
+
+Worker.prototype.addPendingToStack = function () {
+  const len = this.pendingStack.length
+  if (len === 0) return
+  if (this.sortLatest && this.sorted) {
+    // presort pending items
+    if (len > 1) this.pendingStack.sort(sortStackByClockAndSeq)
+    // while stack is in sort order push each pending into stack
+    for (var i = 0; i < this.pendingStack.length; i++) {
+      if (this.sorted && this.stack.length && sortStackByClockAndSeq(this.stack[this.stack.length - 1], this.pendingStack[i]) < 0) {
+        this.sorted = false
+      }
+      this.stack.push(this.pendingStack[i])
+    }
+  } else {
+    Array.prototype.push.apply(this.stack, this.pendingStack)
+  }
+  this.sorted = false
+  this.pendingStack = []
 }
 
 function copyLock (lock) {
@@ -222,8 +260,9 @@ function sortNodesByClock (a, b) {
 function sortStackByClockAndSeq (a, b) {
   a = a.node || a.value
   b = b.node || b.value
-  if (a && !b) return 1
+  if (a && !b) return -1
   if (b && !a) return 1
+  if (!a && !b) return 0
   var sortValue = sortNodesByClock(a, b)
   if (sortValue !== 0) return sortValue
   // // same time, so use sequence to order
@@ -237,9 +276,9 @@ function sortStackByClockAndSeq (a, b) {
 
 function pop (iterator, worker) {
   while (true) {
-    var len = worker.stack.length
+    var len = worker.stack.length || worker.unfinished || worker.pendingStack.length
     if (len) {
-      if (iterator._sortLatest) worker.stack.sort(sortStackByClockAndSeq)
+      worker.sort()
       var top = worker.stack.pop()
       if (top.node && !iterator._isHead(top.node, worker)) {
         if (!allSkips(worker.stack, iterator, worker)) {
@@ -269,13 +308,13 @@ function pop (iterator, worker) {
 }
 
 function pushPointer (iterator, worker, ptr, i) {
-  var index = worker.stack.push({i, node: ptr, fork: null}) - 1
+  var index = worker.pendingStack.push({i, node: ptr, fork: null}) - 1
   worker.pending++
   iterator._db._getPointer(ptr.feed, ptr.seq, false, done)
 
   function done (err, node) {
     if (err) worker.error = err
-    else worker.stack[index].node = node
+    else worker.pendingStack[index].node = node
     if (--worker.pending) return
     if (worker.error) return worker.callback(err)
     next(iterator, worker, worker.callback)
@@ -283,13 +322,13 @@ function pushPointer (iterator, worker, ptr, i) {
 }
 
 function pushFork (iterator, worker, ptrs, i) {
-  var index = worker.stack.push({i, node: null, fork: null}) - 1
+  var index = worker.pendingStack.push({i, node: null, fork: null}) - 1
   worker.pending++
   iterator._db._getAllPointers(ptrs, false, done)
 
   function done (err, nodes) {
     if (err) worker.error = err
-    else worker.stack[index].fork = nodes
+    else worker.pendingStack[index].fork = nodes
     if (--worker.pending) return
     if (worker.error) return worker.callback(err)
     next(iterator, worker, worker.callback)
@@ -303,7 +342,6 @@ function next (iterator, worker, cb) {
   // trie of the corresponding node.
 
   var top = pop(iterator, worker)
-
   // If nothing was on the stack, it's either because the worker has ended
   // and we should stop.
 
@@ -335,11 +373,15 @@ function next (iterator, worker, cb) {
 
     for (var j = 0; j < sortEnd; j++) {
       var sortValue = j === 4 ? 4 : 3 - j // 3, 2, 1, 0, 4
-
+      // if (iterator._sortLatest) sortValue = j
       // Include our node itself again but update i. This makes sure the
       // node is emitted in the right order
       if (sortValue === node.path[i]) {
-        worker.stack.push({i: i + 1, node, fork: null})
+        if (iterator._sortLatest) {
+          worker.unfinished = {i: i + 1, node, fork: null}
+        } else {
+          worker.pendingStack.push({i: i + 1, node, fork: null})
+        }
         if (sortValue !== 4) continue
       }
 
@@ -354,14 +396,15 @@ function next (iterator, worker, cb) {
       else pushFork(iterator, worker, values, i + 1)
     }
 
-    if (worker.pending) return wait(worker, cb)
+    if (worker.pending) {
+      return wait(worker, cb)
+    }
 
     // Recursively call next again with the updated stack and return.
     // The stack is guaranteed to have been updated in this loop, so this
     // is always safe to do.
     return nextNT(iterator, worker, cb)
   }
-
   worker.value = node
   process.nextTick(cb, null)
 }

--- a/lib/latest.js
+++ b/lib/latest.js
@@ -1,0 +1,212 @@
+var nanoiterator = require('nanoiterator')
+var inherits = require('inherits')
+var options = require('./options')
+var hash = require('./hash')
+var LRU = require('lru')
+
+module.exports = Iterator
+
+function Iterator (db, prefix, opts) {
+  if (!(this instanceof Iterator)) return new Iterator(db, prefix, opts)
+  if (!opts) opts = {}
+
+  nanoiterator.call(this)
+
+  var cacheMax = opts.cacheSize || 128
+
+  this._keyCache = new LRU(cacheMax)
+  this._db = db
+  this._prefix = prefix
+  this.queue = []
+  this.queueNeedsSorting = true
+  this._end = 0
+  this._start = 0
+  this._map = options.map(opts, db)
+  this._reduce = options.reduce(opts, db)
+}
+
+inherits(Iterator, nanoiterator)
+
+Iterator.prototype._open = function (cb) {
+  var self = this
+
+  // do a prefix search to find the heads for the prefix
+  // we are trying to scan
+  var opts = {prefix: true, map: false, reduce: false}
+  this._db.get(this._prefix, opts, function (err, heads) {
+    if (err) return cb(err)
+
+    self._hash = hash(self._prefix, false)
+    self._start = self._hash.length
+    self._end = Infinity
+    self.queue = heads.map(h => ({ node: h, index: 0 }))
+    cb()
+  })
+}
+
+Iterator.prototype._next = function (cb) {
+  if (!this.queue.length) {
+    cb(null)
+    return
+  }
+  // sort stream queue first to ensure that you always get the latest node
+  // this requires offsetting feeds sequences based on when it started in relation to others
+  // console.log('next', this.queue.map(n => n.node.key))
+  if (this.queueNeedsSorting) {
+    this.queue.sort(sortStackByClockAndSeq)
+    this.queueNeedsSorting = false
+    // console.log('sorted', this.queue.map(n => n.node.key))
+  }
+  var data = this.queue.pop()
+  var node = data.node
+  this._readNext(node, data.index, (err, match) => {
+    if (err) {
+      return cb(err)
+    }
+    if (!match) return this._next(cb)
+    // check if really a match and not encountered before
+    this._check(node, (err, matchingNode) => {
+      if (err) return cb(err)
+      if (!matchingNode) this._next(cb)
+      else {
+        this._keyCache.set(node.key, true)
+        // console.log('callbak')
+        return cb(null, matchingNode)
+      }
+    })
+  })
+}
+
+Iterator.prototype._check = function (node, cb) {
+  // is it actually a match and not a collision
+  if (!(node && node.key && node.key.indexOf(this._prefix) === 0)) return cb(null)
+  // have we encountered this node before
+  if (this._keyCache.get(node.key)) return cb(null)
+  // it is not in the cache but might still be a duplicate if cache is full
+  // if (keyCache.length === cacheMax) {
+  // so check if this is the first instance of the node
+  // TODO: Atm this is a bit of a hack to get conflicting values
+  // ideally this should not need to retraverse the trie.
+  // Potential issue here when db is updated after stream was created!
+  return this._db.get(node.key, (err, latest) => {
+    if (err) cb(err)
+    if (sortNodesByClock(node, Array.isArray(latest) ? latest[0] : latest) >= 0) {
+      cb(null, latest)
+    } else {
+      cb(null)
+    }
+  })
+}
+
+Iterator.prototype._readNext = function readNext (node, i, cb) {
+  var writers = this._db._writers
+  var trie
+  var missing = 0
+  var error
+  var vals
+  for (; i < this._hash.length - 1; i++) {
+    if (node.path[i] === this._hash.path[i]) continue
+    // check trie
+    trie = node.trie[i]
+    if (!trie) {
+      return cb(null)
+    }
+    vals = trie[this._hash[i]]
+    // not found
+    if (!vals || !vals.length) {
+      return cb(null)
+    }
+
+    missing = vals.length
+    error = null
+    for (var j = 0; j < vals.length; j++) {
+      // fetch potential
+      writers[vals[j].feed].get(vals[j].seq, (err, val) => {
+        if (err) {
+          error = err
+        } else {
+          this._pushToQueue({ node: val, index: i })
+        }
+        missing--
+        if (!missing) {
+          cb(error)
+        }
+      })
+    }
+    return
+  }
+
+  // Traverse the rest of the node's trie, recursively,
+  // hunting for more nodes with the desired prefix.
+  for (; i < node.trie.length; i++) {
+    trie = node.trie[i] || []
+    for (j = 0; j < trie.length; j++) {
+      var entrySet = trie[j] || []
+      for (var el = 0; el < entrySet.length; el++) {
+        var entry = entrySet[el]
+        missing++
+        writers[entry.feed].get(entry.seq, (err, val) => {
+          if (err) {
+            error = err
+          } else if (val.key && val.value) {
+            this._pushToQueue({ node: val, index: i + 1 })
+          }
+          missing--
+          if (!missing) {
+            if (i < node.trie.length) {
+              this._pushToQueue({ node: node, index: i + 1 })
+              cb(error, false)
+            } else {
+              cb(error, true)
+            }
+          }
+        })
+      }
+    }
+    if (missing > 0) return
+  }
+  return cb(null, true)
+}
+
+Iterator.prototype._pushToQueue = function (item) {
+  if (!this.queueNeedsSorting && this.queue.length) {
+    this.queueNeedsSorting = sortStackByClockAndSeq(this.queue[this.queue.length - 1], item) < 0
+  }
+  this.queue.push(item)
+}
+
+Iterator.prototype._prereturn = function (nodes) {
+  if (this._map) nodes = nodes.map(this._map)
+  if (this._reduce) return nodes.reduce(this._reduce)
+  return nodes
+}
+
+function sortNodesByClock (a, b) {
+  var isGreater = false
+  var isLess = false
+  var length = a.clock.length
+  if (b.clock.length > length) length = b.clock.length
+  for (var i = 0; i < length; i++) {
+    var diff = (a.clock[i] || 0) - (b.clock[i] || 0)
+    if (diff > 0) isGreater = true
+    if (diff < 0) isLess = true
+  }
+  if (isGreater && isLess) return 0
+  if (isLess) return -1
+  if (isGreater) return 1
+  return 0
+}
+
+function sortStackByClockAndSeq (a, b) {
+  a = a.node
+  b = b.node
+  var sortValue = sortNodesByClock(a, b)
+  if (sortValue !== 0) return sortValue
+  // // same time, so use sequence to order
+  if (a.feed === b.feed) return a.seq - b.seq
+  var bOffset = b.clock.reduce((p, v) => p + v, b.seq)
+  var aOffset = a.clock.reduce((p, v) => p + v, a.seq)
+  // if real sequence is the same then return sort on feed
+  if (bOffset === aOffset) return b.feed - a.feed
+  return aOffset - bOffset
+}


### PR DESCRIPTION
@mafintosh this is just a quick stab at sorting the stream by latest added node.

This is not super efficient at the moment, as for each pop it is sorting the worker's stack. This could and should be optimised by checking if a sort is needed when pushing a new value to the stack - and only sorting if its needed. I started implementing this optimisation but it requires quite a lot of changes to deal with pending. So figured its best to check with you first, to gage if this method of sorting is heading in the right direction. 
