### PR TITLE
Handle edge cases in 'authorized'

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,8 @@ HyperDB.prototype.authorized = function (key, cb) {
   if (!cb) cb = noop
   var self = this
 
+  if (this.key.equals(key)) return process.nextTick(cb, null, true)
+
   this.heads(function (err, heads) {
     if (err) return cb(err)
     for (var i = 0; i < heads.length; i++) {

--- a/test/auth.js
+++ b/test/auth.js
@@ -18,6 +18,24 @@ tape('authorized writer passes "authorized" api', function (t) {
   })
 })
 
+tape('authorized writer passes "authorized" api', function (t) {
+  create.two(function (a, b) {
+    b.put('foo', 'bar', function (err) {
+      t.error(err)
+      a.authorized(a.local.key, function (err, auth) {
+        t.error(err)
+        t.equals(auth, true)
+        b.authorized(b.local.key, function (err, auth) {
+          t.error(err)
+          t.equals(auth, true)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+
 tape('unauthorized writer fails "authorized" api', function (t) {
   var a = create.one()
   a.ready(function () {

--- a/test/auth.js
+++ b/test/auth.js
@@ -3,10 +3,17 @@ var create = require('./helpers/create')
 
 tape('authorized writer passes "authorized" api', function (t) {
   create.two(function (a, b) {
-    b.authorized(b.local.key, function (err, auth) {
+    a.put('foo', 'bar', function (err) {
       t.error(err)
-      t.equals(auth, true)
-      t.end()
+      a.authorized(a.local.key, function (err, auth) {
+        t.error(err)
+        t.equals(auth, true)
+        b.authorized(b.local.key, function (err, auth) {
+          t.error(err)
+          t.equals(auth, true)
+          t.end()
+        })
+      })
     })
   })
 })
@@ -35,7 +42,11 @@ tape('local unauthorized writes =/> authorized', function (t) {
         b.authorized(b.local.key, function (err, auth) {
           t.error(err)
           t.equals(auth, false)
-          t.end()
+          b.authorized(a.local.key, function (err, auth) {
+            t.error(err)
+            t.equals(auth, true)
+            t.end()
+          })
         })
       })
     })

--- a/test/auth.js
+++ b/test/auth.js
@@ -35,7 +35,6 @@ tape('authorized writer passes "authorized" api', function (t) {
   })
 })
 
-
 tape('unauthorized writer fails "authorized" api', function (t) {
   var a = create.one()
   a.ready(function () {


### PR DESCRIPTION
1. always recognize the original db author as authorized
2. recognize others as authorized when the only head is by the author in question