### PR TITLE
Add option to pass in secret key

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function HyperDB (storage, key, opts) {
   this.discoveryKey = this.key ? hypercore.discoveryKey(this.key) : null
   this.sourceFeedOpts = {
     secretKey: opts.secretKey || null,
-    storeSecretKey: opts.hasOwnProperty('storeSecretKey') ? opts.storeSecretKey : true
+    storeSecretKey: opts.storeSecretKey !== false
   }
   this.source = checkout ? checkout.source : null
   this.local = checkout ? checkout.local : null

--- a/index.js
+++ b/index.js
@@ -41,7 +41,10 @@ function HyperDB (storage, key, opts) {
 
   this.key = typeof key === 'string' ? Buffer.from(key, 'hex') : key
   this.discoveryKey = this.key ? hypercore.discoveryKey(this.key) : null
-  this.secretKey = opts.secretKey || null
+  this.sourceFeedOpts = {
+    secretKey: opts.secretKey || null,
+    storeSecretKey: opts.hasOwnProperty('storeSecretKey') ? opts.storeSecretKey : true
+  }
   this.source = checkout ? checkout.source : null
   this.local = checkout ? checkout.local : null
   this.localContent = checkout ? checkout.localContent : null
@@ -428,16 +431,15 @@ HyperDB.prototype._getAllPointers = function (list, isPut, cb) {
   }
 }
 
-HyperDB.prototype._writer = function (dir, key, secretKey) {
+HyperDB.prototype._writer = function (dir, key, opts) {
   var writer = key && this._byKey.get(key.toString('hex'))
   if (writer) return writer
 
   var self = this
-  var opts = {sparse: this.sparse}
-  if (secretKey) {
-    opts.secretKey = secretKey
-    opts.storeSecretKey = true
-  }
+  opts = Object.assign({}, opts, {
+    sparse: this.sparse
+  })
+
   var feed = hypercore(storage, key, opts)
 
   writer = new Writer(self, feed)
@@ -564,7 +566,7 @@ HyperDB.prototype._ready = function (cb) {
     return
   }
 
-  if (!this.source) this.source = feed('source', this.key, this.secretKey)
+  if (!this.source) this.source = feed('source', this.key, this.sourceFeedOpts)
 
   this.source.ready(function (err) {
     if (err) return done(err)
@@ -596,8 +598,8 @@ HyperDB.prototype._ready = function (cb) {
     cb(null)
   }
 
-  function feed (dir, key, secretKey) {
-    var writer = self._writer(dir, key, secretKey)
+  function feed (dir, key, feedOpts) {
+    var writer = self._writer(dir, key, feedOpts)
     self._pushWriter(writer)
     return writer._feed
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -419,3 +419,24 @@ tape('createWriteStream pipe', function (t) {
     })
   }
 })
+
+tape('create with precreated keypair', function (t) {
+  var crypto = require('hypercore/lib/crypto')
+  var keyPair = crypto.keyPair()
+
+  var db = create.one(keyPair.publicKey, {secretKey: keyPair.secretKey})
+  db.put('hello', 'world', function (err, node) {
+    t.same(node.value, 'world')
+    t.error(err, 'no error')
+    t.same(db.key, keyPair.publicKey, 'pubkey matches')
+    db.source._storage.secretKey.read(0, keyPair.secretKey.length, function (err, secretKey) {
+      t.error(err, 'no error')
+      t.same(secretKey, keyPair.secretKey, 'secret key is stored')
+    })
+    db.get('hello', function (err, node) {
+      t.error(err, 'no error')
+      t.same(node.value, 'world', 'same value')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Allow to pass in a precreated key pair and store the secret key with the source feed. This allows to first create the key pair and then the hyperdb - useful e.g. if you want to manage many hyperdb and store them in dirs named after the pubkeys (otherwise you'd have to move the db after creation because you'd only know the pubkey after creation).