### PR TITLE
WIP: Lexicographic iteration

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -1,4 +1,3 @@
-var hash = require('./hash')
 var options = require('./options')
 
 module.exports = get
@@ -17,7 +16,7 @@ function GetRequest (db, key, opts) {
   this._callback = noop
   this._options = opts || null
   this._prefixed = !!(opts && opts.prefix)
-  this._path = (opts && opts.path) || hash(key, !this._prefixed)
+  this._path = (opts && opts.path) || db._path(key, !this._prefixed)
   this._db = db
   this._error = null
   this._active = 0

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,3 +1,5 @@
+// var sodium = require('sodium-universal')
+
 hash.TERMINATE = 5
 hash.SEPARATE = 4
 

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,11 +1,17 @@
-// var sodium = require('sodium-universal')
+var sodium = require('sodium-universal')
+
+var KEY = Buffer.alloc(16)
+var OUT = Buffer.alloc(8)
 
 hash.TERMINATE = 5
 hash.SEPARATE = 4
 
-module.exports = hash
+module.exports = function getHash (opts) {
+  if (!opts) return hash
+  return opts.lexint ? lexint : hash
+}
 
-function hash (keys, terminate) {
+function lexint (keys, terminate) {
   if (typeof keys === 'string') keys = split(keys)
   if (!keys.length) return []
 
@@ -17,7 +23,7 @@ function hash (keys, terminate) {
   var offset = 0
   for (var i = 0; i < keys.length; i++) {
     var buf = Buffer.from(keys[i])
-    expandHash(buf, all, offset)
+    expandComponent(buf, all, offset)
     offset += lengths[i] * 4
     all[offset++] = hash.SEPARATE
   }
@@ -27,7 +33,26 @@ function hash (keys, terminate) {
   return all
 }
 
-function expandHash (next, out, offset) {
+function hash (keys, terminate) {
+  if (typeof keys === 'string') keys = split(keys)
+  if (!keys.length) return []
+
+  var all = new Array(keys.length * 32  + keys.length + (terminate ? 1 : 0))
+
+  var offset = 0
+  for (var i = 0; i < keys.length; i++) {
+    sodium.crypto_shorthash(OUT, Buffer.from(keys[i]), KEY)
+    expandComponent(OUT, all, i * 32)
+    offset += 32
+    all[offset++] = hash.SEPARATE
+  }
+
+  if (terminate) all[all.length - 1] = hash.TERMINATE
+
+  return all
+}
+
+function expandComponent (next, out, offset) {
   for (var i = 0; i < next.length; i++) {
     var n = next[i]
 

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -22,7 +22,6 @@ function hash (keys, terminate) {
 
   if (terminate) all[all.length - 1] = hash.TERMINATE
 
-  console.log('ALL:', all.join(''), 'keys:', keys.join('/'))
   return all
 }
 

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,25 +1,28 @@
-var sodium = require('sodium-universal')
-
-var KEY = Buffer.alloc(16)
-var OUT = Buffer.alloc(8)
-
-hash.TERMINATE = 4
-hash.LENGTH = 32
+hash.TERMINATE = 5
+hash.SEPARATE = 4
 
 module.exports = hash
 
 function hash (keys, terminate) {
   if (typeof keys === 'string') keys = split(keys)
+  if (!keys.length) return []
 
-  var all = new Array(keys.length * 32 + (terminate ? 1 : 0))
+  var lengths = keys.map(k => k.length)
+  var totalSize = lengths.reduce(sum, 0) * 4
 
+  var all = new Array(totalSize + keys.length + (terminate ? 1 : 0))
+
+  var offset = 0
   for (var i = 0; i < keys.length; i++) {
-    sodium.crypto_shorthash(OUT, Buffer.from(keys[i]), KEY)
-    expandHash(OUT, all, i * 32)
+    var buf = Buffer.from(keys[i])
+    expandHash(buf, all, offset)
+    offset += lengths[i] * 4
+    all[offset++] = hash.SEPARATE
   }
 
-  if (terminate) all[all.length - 1] = 4
+  if (terminate) all[all.length - 1] = hash.TERMINATE
 
+  console.log('ALL:', all.join(''), 'keys:', keys.join('/'))
   return all
 }
 
@@ -27,14 +30,16 @@ function expandHash (next, out, offset) {
   for (var i = 0; i < next.length; i++) {
     var n = next[i]
 
-    for (var j = 0; j < 4; j++) {
+    for (var j = 3; j >= 0; j--) {
       var r = n & 3
-      out[offset++] = r
+      out[offset + 4 * i + j] = r
       n -= r
       n /= 4
     }
   }
 }
+
+function sum (s, n) { return s + n }
 
 function split (key) {
   var list = key.split('/')

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -1,10 +1,10 @@
 var nanoiterator = require('nanoiterator')
 var inherits = require('inherits')
-var hash = require('./hash')
+var path = require('./path')
 var options = require('./options')
 
-var SORT_GT = [3, 2, 1, 0, hash.SEPARATE]
-var SORT_GTE = [3, 2, 1, 0, hash.SEPARATE, hash.TERMINATE]
+var SORT_GT = [3, 2, 1, 0, path.SEPARATE]
+var SORT_GTE = [3, 2, 1, 0, path.SEPARATE, path.TERMINATE]
 
 module.exports = Iterator
 
@@ -14,11 +14,9 @@ function Iterator (db, prefix, opts) {
 
   nanoiterator.call(this)
 
-  this._hash = hash(opts)
-
   this._db = db
   this._stack = [{
-    path: prefix ? this._hash(prefix, false) : [],
+    path: prefix ? this._db._path(prefix, false) : [],
     node: null,
     i: 0
   }]
@@ -75,7 +73,7 @@ Iterator.prototype._singleNode = function (top, cb) {
   var node = top.node
 
   for (var i = top.i; i < node.trie.length; i++) {
-    if (!this._recursive && node.path[i - 1] === hash.SEPARATE) break
+    if (!this._recursive && node.path[i - 1] === path.SEPARATE) break
 
     var bucket = i < node.trie.length && node.trie[i]
     if (!bucket) continue
@@ -135,7 +133,7 @@ Iterator.prototype._filterResult = function (nodes, i) {
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
     if (this._recursive && node.path.length !== i) continue
-    if (!this._recursive && node.path[i - 1] !== hash.SEPARATE) continue
+    if (!this._recursive && node.path[i - 1] !== path.SEPARATE) continue
     if (!isPrefix(node.key, this._prefix)) continue
 
     if (!result) result = []

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -38,7 +38,6 @@ function Iterator (db, prefix, opts) {
 inherits(Iterator, nanoiterator)
 
 Iterator.prototype._pushPointer = function (ptr, i, cb) {
-  console.log('PUSHING POINTER:', ptr, 'i:', i)
   var self = this
   var top = {path: null, node: null, i}
 
@@ -56,7 +55,6 @@ Iterator.prototype._pushPointer = function (ptr, i, cb) {
 }
 
 Iterator.prototype._pushNode = function (node, i) {
-  console.log('PUSHING NODE:', node, 'i:', i)
   this._stack.push({
     path: null,
     node,
@@ -65,7 +63,6 @@ Iterator.prototype._pushNode = function (node, i) {
 }
 
 Iterator.prototype._pushPrefix = function (path, i, val) {
-  console.log('PUSHING PREFIX:', path, 'i:', i, 'val:', val)
   this._stack.push({
     path: (i < path.length ? path.slice(0, i) : path).concat(val),
     node: null,
@@ -76,17 +73,13 @@ Iterator.prototype._pushPrefix = function (path, i, val) {
 // fast case
 Iterator.prototype._singleNode = function (top, cb) {
   var node = top.node
-  console.log('In _singleNode, node:', node, 'trie:', JSON.stringify(node.trie))
 
   for (var i = top.i; i < node.trie.length; i++) {
-    console.log('MIGHT BREAK')
     if (!this._recursive && node.path[i - 1] === hash.SEPARATE) break
-    console.log('DID NOT BREAK')
 
     var bucket = i < node.trie.length && node.trie[i]
     if (!bucket) continue
 
-    console.log('BUCKET:', bucket, 'i:', i)
 
     var val = node.path[i]
     var order = this._sortOrder(i)
@@ -110,14 +103,12 @@ Iterator.prototype._singleNode = function (top, cb) {
   }
 
   if (!node.value || !isPrefix(node.key, this._prefix)) return true
-  console.log('returning node in singleNode:', node)
   cb(null, this._prereturn([node]))
   return false
 }
 
 // slow case
 Iterator.prototype._multiNode = function (path, nodes, cb) {
-  console.log('in multiNode, path:', path, 'nodes.length:', nodes.length)
   if (!nodes.length) return this._next(cb)
   if (nodes.length === 1) {
     this._pushNode(nodes[0], path.length)
@@ -125,20 +116,16 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
   }
 
   var ptr = path.length
-  console.log('ptr:', ptr, 'path:', path)
 
   var order = this._sortOrder(ptr)
 
   for (var i = 0; i < order.length; i++) {
     var sortValue = order[i]
     if (!visitTrie(nodes, ptr, sortValue)) continue
-    console.log('PUSHING PREFIX IN MULTINODE')
     this._pushPrefix(path, ptr, sortValue)
   }
 
-  console.log('BEFORE FILTERING:', nodes)
   nodes = this._filterResult(nodes, ptr)
-  console.log('AFTER FILTERING:', nodes)
   if (nodes && !allDeletes(nodes)) return cb(null, this._prereturn(nodes))
   this._next(cb)
 }
@@ -150,11 +137,9 @@ Iterator.prototype._filterResult = function (nodes, i) {
 
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
-    console.log('CONSIDERING:', node, 'i:', i, 'node.path[i - 1]:', node.path[i - 1], 'node.path.length:', node.path.length)
     if (this._recursive && node.path.length !== i) continue
     if (!this._recursive && node.path[i - 1] !== hash.SEPARATE) continue
     if (!isPrefix(node.key, this._prefix)) continue
-    console.log('DID NOT FILTER')
 
     if (!result) result = []
 
@@ -177,13 +162,11 @@ Iterator.prototype._next = function (cb) {
 
   while (true) {
     top = this._stack.pop()
-    console.log('TOP:', top)
     if (!top) return cb(null, null)
     if (!top.node) break
     if (!this._singleNode(top, cb)) return
   }
 
-  console.log('in _next looking up prefix:', top.path)
   this._lookupPrefix(top.path, cb)
 }
 
@@ -199,7 +182,6 @@ Iterator.prototype._lookupPrefix = function (path, cb) {
 }
 
 Iterator.prototype._prereturn = function (nodes) {
-  console.log('RETURNING NODES:', nodes)
   if (this._map) nodes = nodes.map(this._map)
   if (this._reduce) return nodes.reduce(this._reduce)
   return nodes

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -22,6 +22,8 @@ function Iterator (db, prefix, opts) {
   }]
 
   this._recursive = opts.recursive !== false
+  this._lt = opts.lt
+  this._lte = opts.lte
   this._gt = !!opts.gt
   this._start = this._stack[0].path.length
   this._map = options.map(opts, db)
@@ -177,6 +179,10 @@ Iterator.prototype._lookupPrefix = function (path, cb) {
 }
 
 Iterator.prototype._prereturn = function (nodes) {
+  if ((this._lt || this._lte) && nodes.length) {
+    var max = this._lt ? -1 : 0
+    if (!(nodes[0].key.localeCompare(this._lt || this._lte) <= max)) return null
+  }
   if (this._map) nodes = nodes.map(this._map)
   if (this._reduce) return nodes.reduce(this._reduce)
   return nodes

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -3,8 +3,8 @@ var inherits = require('inherits')
 var hash = require('./hash')
 var options = require('./options')
 
-var SORT_GT = [3, 2, 1, 0]
-var SORT_GTE = [3, 2, 1, 0, 4]
+var SORT_GT = [3, 2, 1, 0, hash.SEPARATE]
+var SORT_GTE = [3, 2, 1, 0, hash.SEPARATE, hash.TERMINATE]
 
 module.exports = Iterator
 
@@ -24,7 +24,6 @@ function Iterator (db, prefix, opts) {
   this._recursive = opts.recursive !== false
   this._gt = !!opts.gt
   this._start = this._stack[0].path.length
-  this._end = this._recursive ? Infinity : this._start + hash.LENGTH
   this._map = options.map(opts, db)
   this._reduce = options.reduce(opts, db)
   this._collisions = []
@@ -78,6 +77,8 @@ Iterator.prototype._singleNode = function (top, cb) {
     var bucket = i < node.trie.length && node.trie[i]
     if (!bucket) continue
 
+    if (!this._recursive && node.path[i] === hash.SEPARATE) break
+
     var val = node.path[i]
     var order = this._sortOrder(i)
 
@@ -114,7 +115,7 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
 
   var ptr = path.length
 
-  if (ptr < this._end) {
+  if (this.recursive || path[ptr - 1] !== hash.SEPARATE) {
     var order = this._sortOrder(ptr)
 
     for (var i = 0; i < order.length; i++) {
@@ -136,7 +137,7 @@ Iterator.prototype._filterResult = function (nodes, i) {
 
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
-    if (node.path.length !== i && i !== this._end) continue
+    if (node.path.length !== i && (this._recursive || node.path[i] !== hash.SEPARATE)) continue
     if (!isPrefix(node.key, this._prefix)) continue
 
     if (!result) result = []

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -5,6 +5,8 @@ var options = require('./options')
 
 var SORT_GT = [3, 2, 1, 0, hash.SEPARATE]
 var SORT_GTE = [3, 2, 1, 0, hash.SEPARATE, hash.TERMINATE]
+//var SORT_GTE = [0, 1, 2, 3, hash.SEPARATE, hash.TERMINATE]
+//var SORT_GT = [0, 1, 2, 3, hash.SEPARATE]
 
 module.exports = Iterator
 
@@ -36,6 +38,7 @@ function Iterator (db, prefix, opts) {
 inherits(Iterator, nanoiterator)
 
 Iterator.prototype._pushPointer = function (ptr, i, cb) {
+  console.log('PUSHING POINTER:', ptr, 'i:', i)
   var self = this
   var top = {path: null, node: null, i}
 
@@ -53,6 +56,7 @@ Iterator.prototype._pushPointer = function (ptr, i, cb) {
 }
 
 Iterator.prototype._pushNode = function (node, i) {
+  console.log('PUSHING NODE:', node, 'i:', i)
   this._stack.push({
     path: null,
     node,
@@ -61,6 +65,7 @@ Iterator.prototype._pushNode = function (node, i) {
 }
 
 Iterator.prototype._pushPrefix = function (path, i, val) {
+  console.log('PUSHING PREFIX:', path, 'i:', i, 'val:', val)
   this._stack.push({
     path: (i < path.length ? path.slice(0, i) : path).concat(val),
     node: null,
@@ -71,13 +76,17 @@ Iterator.prototype._pushPrefix = function (path, i, val) {
 // fast case
 Iterator.prototype._singleNode = function (top, cb) {
   var node = top.node
-  var end = Math.min(this._end, node.trie.length)
+  console.log('In _singleNode, node:', node, 'trie:', JSON.stringify(node.trie))
 
-  for (var i = top.i; i < end; i++) {
+  for (var i = top.i; i < node.trie.length; i++) {
+    console.log('MIGHT BREAK')
+    if (!this._recursive && node.path[i - 1] === hash.SEPARATE) break
+    console.log('DID NOT BREAK')
+
     var bucket = i < node.trie.length && node.trie[i]
     if (!bucket) continue
 
-    if (!this._recursive && node.path[i] === hash.SEPARATE) break
+    console.log('BUCKET:', bucket, 'i:', i)
 
     var val = node.path[i]
     var order = this._sortOrder(i)
@@ -101,12 +110,14 @@ Iterator.prototype._singleNode = function (top, cb) {
   }
 
   if (!node.value || !isPrefix(node.key, this._prefix)) return true
+  console.log('returning node in singleNode:', node)
   cb(null, this._prereturn([node]))
   return false
 }
 
 // slow case
 Iterator.prototype._multiNode = function (path, nodes, cb) {
+  console.log('in multiNode, path:', path, 'nodes.length:', nodes.length)
   if (!nodes.length) return this._next(cb)
   if (nodes.length === 1) {
     this._pushNode(nodes[0], path.length)
@@ -114,18 +125,20 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
   }
 
   var ptr = path.length
+  console.log('ptr:', ptr, 'path:', path)
 
-  if (this.recursive || path[ptr - 1] !== hash.SEPARATE) {
-    var order = this._sortOrder(ptr)
+  var order = this._sortOrder(ptr)
 
-    for (var i = 0; i < order.length; i++) {
-      var sortValue = order[i]
-      if (!visitTrie(nodes, ptr, sortValue)) continue
-      this._pushPrefix(path, path.length, sortValue)
-    }
+  for (var i = 0; i < order.length; i++) {
+    var sortValue = order[i]
+    if (!visitTrie(nodes, ptr, sortValue)) continue
+    console.log('PUSHING PREFIX IN MULTINODE')
+    this._pushPrefix(path, ptr, sortValue)
   }
 
+  console.log('BEFORE FILTERING:', nodes)
   nodes = this._filterResult(nodes, ptr)
+  console.log('AFTER FILTERING:', nodes)
   if (nodes && !allDeletes(nodes)) return cb(null, this._prereturn(nodes))
   this._next(cb)
 }
@@ -133,12 +146,15 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
 Iterator.prototype._filterResult = function (nodes, i) {
   var result = null
 
-  nodes.sort(byKey)
+  // nodes.sort(byKey)
 
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
-    if (node.path.length !== i && (this._recursive || node.path[i] !== hash.SEPARATE)) continue
+    console.log('CONSIDERING:', node, 'i:', i, 'node.path[i - 1]:', node.path[i - 1], 'node.path.length:', node.path.length)
+    if (this._recursive && node.path.length !== i) continue
+    if (!this._recursive && node.path[i - 1] !== hash.SEPARATE) continue
     if (!isPrefix(node.key, this._prefix)) continue
+    console.log('DID NOT FILTER')
 
     if (!result) result = []
 
@@ -161,11 +177,13 @@ Iterator.prototype._next = function (cb) {
 
   while (true) {
     top = this._stack.pop()
+    console.log('TOP:', top)
     if (!top) return cb(null, null)
     if (!top.node) break
     if (!this._singleNode(top, cb)) return
   }
 
+  console.log('in _next looking up prefix:', top.path)
   this._lookupPrefix(top.path, cb)
 }
 
@@ -181,6 +199,7 @@ Iterator.prototype._lookupPrefix = function (path, cb) {
 }
 
 Iterator.prototype._prereturn = function (nodes) {
+  console.log('RETURNING NODES:', nodes)
   if (this._map) nodes = nodes.map(this._map)
   if (this._reduce) return nodes.reduce(this._reduce)
   return nodes

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -22,8 +22,6 @@ function Iterator (db, prefix, opts) {
   }]
 
   this._recursive = opts.recursive !== false
-  this._lt = opts.lt
-  this._lte = opts.lte
   this._gt = !!opts.gt
   this._start = this._stack[0].path.length
   this._map = options.map(opts, db)
@@ -179,10 +177,6 @@ Iterator.prototype._lookupPrefix = function (path, cb) {
 }
 
 Iterator.prototype._prereturn = function (nodes) {
-  if ((this._lt || this._lte) && nodes.length) {
-    var max = this._lt ? -1 : 0
-    if (!(nodes[0].key.localeCompare(this._lt || this._lte) <= max)) return null
-  }
   if (this._map) nodes = nodes.map(this._map)
   if (this._reduce) return nodes.reduce(this._reduce)
   return nodes

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -14,9 +14,11 @@ function Iterator (db, prefix, opts) {
 
   nanoiterator.call(this)
 
+  this._hash = hash(opts)
+
   this._db = db
   this._stack = [{
-    path: prefix ? hash(prefix, false) : [],
+    path: prefix ? this._hash(prefix, false) : [],
     node: null,
     i: 0
   }]

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -133,8 +133,6 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
 Iterator.prototype._filterResult = function (nodes, i) {
   var result = null
 
-  // nodes.sort(byKey)
-
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
     if (this._recursive && node.path.length !== i) continue

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -5,8 +5,6 @@ var options = require('./options')
 
 var SORT_GT = [3, 2, 1, 0, hash.SEPARATE]
 var SORT_GTE = [3, 2, 1, 0, hash.SEPARATE, hash.TERMINATE]
-//var SORT_GTE = [0, 1, 2, 3, hash.SEPARATE, hash.TERMINATE]
-//var SORT_GT = [0, 1, 2, 3, hash.SEPARATE]
 
 module.exports = Iterator
 
@@ -79,7 +77,6 @@ Iterator.prototype._singleNode = function (top, cb) {
 
     var bucket = i < node.trie.length && node.trie[i]
     if (!bucket) continue
-
 
     var val = node.path[i]
     var order = this._sortOrder(i)
@@ -188,11 +185,6 @@ Iterator.prototype._prereturn = function (nodes) {
 Iterator.prototype._sortOrder = function (i) {
   var gt = this._gt || !this._start
   return gt && this._start === i ? SORT_GT : SORT_GTE
-}
-
-function byKey (a, b) {
-  var k = b.key.localeCompare(a.key)
-  return k || b.feed - a.feed
 }
 
 function allDeletes (nodes) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -3,13 +3,15 @@ var sodium = require('sodium-universal')
 var KEY = Buffer.alloc(16)
 var OUT = Buffer.alloc(8)
 
-hash.TERMINATE = 5
-hash.SEPARATE = 4
+path.TERMINATE = 5
+path.SEPARATE = 4
 
-module.exports = function getHash (opts) {
-  if (!opts) return hash
+function path (opts) {
+  if (!opts) return lexint
   return opts.lexint ? lexint : hash
 }
+
+module.exports = path
 
 function lexint (keys, terminate) {
   if (typeof keys === 'string') keys = split(keys)
@@ -25,10 +27,10 @@ function lexint (keys, terminate) {
     var buf = Buffer.from(keys[i])
     expandComponent(buf, all, offset)
     offset += lengths[i] * 4
-    all[offset++] = hash.SEPARATE
+    all[offset++] = path.SEPARATE
   }
 
-  if (terminate) all[all.length - 1] = hash.TERMINATE
+  if (terminate) all[all.length - 1] = path.TERMINATE
 
   return all
 }
@@ -37,17 +39,17 @@ function hash (keys, terminate) {
   if (typeof keys === 'string') keys = split(keys)
   if (!keys.length) return []
 
-  var all = new Array(keys.length * 32  + keys.length + (terminate ? 1 : 0))
+  var all = new Array(keys.length * 32 + keys.length + (terminate ? 1 : 0))
 
   var offset = 0
   for (var i = 0; i < keys.length; i++) {
     sodium.crypto_shorthash(OUT, Buffer.from(keys[i]), KEY)
-    expandComponent(OUT, all, i * 32)
+    expandComponent(OUT, all, offset)
     offset += 32
-    all[offset++] = hash.SEPARATE
+    all[offset++] = path.SEPARATE
   }
 
-  if (terminate) all[all.length - 1] = hash.TERMINATE
+  if (terminate) all[all.length - 1] = path.TERMINATE
 
   return all
 }

--- a/lib/put.js
+++ b/lib/put.js
@@ -18,7 +18,6 @@ function PutRequest (db, key, value, clock) {
   this._db = db
   this._path = hash(key, true)
   this._trie = []
-  console.log('PUTTING key:', key, 'with path:', this._path.join(''))
 }
 
 PutRequest.prototype.start = function (heads, cb) {

--- a/lib/put.js
+++ b/lib/put.js
@@ -1,4 +1,4 @@
-var hash = require('./hash')
+var path = require('./path')
 
 module.exports = put
 
@@ -16,7 +16,7 @@ function PutRequest (db, key, value, clock) {
   this._error = null
   this._callback = noop
   this._db = db
-  this._path = hash(key, true)
+  this._path = db._path(key, true)
   this._trie = []
 }
 
@@ -107,13 +107,13 @@ PutRequest.prototype._copyTrie = function (worker, bucket, val) {
     // check if we are the closest node, if so skip this
     // except if we are terminating the val. if so we
     // need to check for collions before making the decision
-    if (i === val && val !== hash.TERMINATE) continue
+    if (i === val && val !== path.TERMINATE) continue
 
     var ptrs = bucket[i] || []
     for (var k = 0; k < ptrs.length; k++) {
       var ptr = ptrs[k]
       // if termination value, push if get(ptr).key !== key
-      if (val === hash.TERMINATE) this._checkCollision(worker, i, ptr.feed, ptr.seq)
+      if (val === path.TERMINATE) this._checkCollision(worker, i, ptr.feed, ptr.seq)
       else this._push(worker, i, ptr.feed, ptr.seq)
     }
   }
@@ -125,7 +125,7 @@ PutRequest.prototype._splitTrie = function (worker, bucket, val) {
 
   // check if we need to split the trie at all
   // i.e. is head still closest and is head not a conflict
-  if (headVal === val && (headVal < hash.TERMINATE || head.key === this.key)) return
+  if (headVal === val && (headVal < path.TERMINATE || head.key === this.key)) return
 
   // push head to the trie
   this._push(worker, headVal, head.feed, head.seq)

--- a/lib/put.js
+++ b/lib/put.js
@@ -18,6 +18,7 @@ function PutRequest (db, key, value, clock) {
   this._db = db
   this._path = hash(key, true)
   this._trie = []
+  console.log('PUTTING key:', key, 'with path:', this._path.join(''))
 }
 
 PutRequest.prototype.start = function (heads, cb) {

--- a/lib/put.js
+++ b/lib/put.js
@@ -108,13 +108,13 @@ PutRequest.prototype._copyTrie = function (worker, bucket, val) {
     // check if we are the closest node, if so skip this
     // except if we are terminating the val. if so we
     // need to check for collions before making the decision
-    if (i === val && val !== 4) continue
+    if (i === val && val !== hash.TERMINATE) continue
 
     var ptrs = bucket[i] || []
     for (var k = 0; k < ptrs.length; k++) {
       var ptr = ptrs[k]
       // if termination value, push if get(ptr).key !== key
-      if (val === 4) this._checkCollision(worker, i, ptr.feed, ptr.seq)
+      if (val === hash.TERMINATE) this._checkCollision(worker, i, ptr.feed, ptr.seq)
       else this._push(worker, i, ptr.feed, ptr.seq)
     }
   }
@@ -126,7 +126,7 @@ PutRequest.prototype._splitTrie = function (worker, bucket, val) {
 
   // check if we need to split the trie at all
   // i.e. is head still closest and is head not a conflict
-  if (headVal === val && (headVal < 4 || head.key === this.key)) return
+  if (headVal === val && (headVal < hash.TERMINATE || head.key === this.key)) return
 
   // push head to the trie
   this._push(worker, headVal, head.feed, head.seq)

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -5,9 +5,11 @@ var reduce = (a, b) => a
 
 exports.one = function (key, opts) {
   if (!opts) opts = {}
-  opts.reduce = reduce
-  opts.valueEncoding = opts.valueEncoding || 'utf-8'
-  return hyperdb(ram, key, opts)
+  var options = opts = Object.assign({
+    reduce,
+    valueEncoding: 'utf-8'
+  }, opts)
+  return hyperdb(ram, key, options)
 }
 
 exports.two = function (opts, cb) {

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -66,7 +66,7 @@ tape('empty prefix iteration', function (t) {
   })
 })
 
-tape.skip('prefix iterate a big db', function (t) {
+tape('prefix iterate a big db', function (t) {
   var db = create.one()
 
   var vals = range(1000, 'foo/#')

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -66,7 +66,7 @@ tape('empty prefix iteration', function (t) {
   })
 })
 
-tape('prefix iterate a big db', function (t) {
+tape.skip('prefix iterate a big db', function (t) {
   var db = create.one()
 
   var vals = range(1000, 'foo/#')

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -123,36 +123,6 @@ tape('mixed nested and non nexted iteration', function (t) {
   })
 })
 
-tape('lt iteration', function (t) {
-  var db = create.one()
-  var vals = ['a', 'b', 'c', 'a/b', 'a/c', 'b/a']
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator({ lt: 'b' }), function (err, map) {
-      t.error(err, 'no error')
-      var keys = Object.keys(map)
-      t.same(keys.sort(), ['a', 'a/b', 'a/c'], 'stopped before lt')
-      t.end()
-    })
-  })
-})
-
-tape('lte iteration', function (t) {
-  var db = create.one()
-  var vals = ['a', 'b', 'c', 'a/b', 'a/c', 'b/a']
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator({ lte: 'b' }), function (err, map) {
-      t.error(err, 'no error')
-      var keys = Object.keys(map)
-      t.same(keys.sort(), ['a', 'a/b', 'a/c', 'b'], 'stopped at lte')
-      t.end()
-    })
-  })
-})
-
 tape('two writers, simple fork', function (t) {
   t.plan(2 * 2 + 1)
 

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -123,6 +123,36 @@ tape('mixed nested and non nexted iteration', function (t) {
   })
 })
 
+tape('lt iteration', function (t) {
+  var db = create.one()
+  var vals = ['a', 'b', 'c', 'a/b', 'a/c', 'b/a']
+
+  put(db, vals, function (err) {
+    t.error(err, 'no error')
+    all(db.iterator({ lt: 'b' }), function (err, map) {
+      t.error(err, 'no error')
+      var keys = Object.keys(map)
+      t.same(keys.sort(), ['a', 'a/b', 'a/c'], 'stopped before lt')
+      t.end()
+    })
+  })
+})
+
+tape('lte iteration', function (t) {
+  var db = create.one()
+  var vals = ['a', 'b', 'c', 'a/b', 'a/c', 'b/a']
+
+  put(db, vals, function (err) {
+    t.error(err, 'no error')
+    all(db.iterator({ lte: 'b' }), function (err, map) {
+      t.error(err, 'no error')
+      var keys = Object.keys(map)
+      t.same(keys.sort(), ['a', 'a/b', 'a/c', 'b'], 'stopped at lte')
+      t.end()
+    })
+  })
+})
+
 tape('two writers, simple fork', function (t) {
   t.plan(2 * 2 + 1)
 

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -84,7 +84,7 @@ tape.skip('prefix iterate a big db', function (t) {
   })
 })
 
-tape('non recursive iteration', function (t) {
+tape.skip('non recursive iteration', function (t) {
   var db = create.one()
 
   var vals = [
@@ -108,7 +108,7 @@ tape('non recursive iteration', function (t) {
   })
 })
 
-tape('mixed nested and non nexted iteration', function (t) {
+tape.skip('mixed nested and non nexted iteration', function (t) {
   var db = create.one()
   var vals = ['a', 'a/a', 'a/b', 'a/c', 'a/a/a', 'a/a/b', 'a/a/c']
   var expected = toMap(vals)
@@ -123,7 +123,7 @@ tape('mixed nested and non nexted iteration', function (t) {
   })
 })
 
-tape('two writers, simple fork', function (t) {
+tape.skip('two writers, simple fork', function (t) {
   t.plan(2 * 2 + 1)
 
   create.two(function (db1, db2, replicate) {
@@ -157,7 +157,7 @@ tape('two writers, simple fork', function (t) {
   })
 })
 
-tape('two writers, one fork', function (t) {
+tape.skip('two writers, one fork', function (t) {
   create.two(function (db1, db2, replicate) {
     run(
       cb => db1.put('0', '0', cb),
@@ -218,7 +218,7 @@ tape('two writers, one fork', function (t) {
   })
 })
 
-tape('two writers, one fork, many values', function (t) {
+tape.skip('two writers, one fork, many values', function (t) {
   var r = range(100, 'i')
 
   create.two(function (db1, db2, replicate) {
@@ -275,7 +275,7 @@ tape('two writers, one fork, many values', function (t) {
   })
 })
 
-tape('two writers, fork', function (t) {
+tape.skip('two writers, fork', function (t) {
   t.plan(2 * 2 + 1)
 
   create.two(function (a, b, replicate) {
@@ -302,7 +302,7 @@ tape('two writers, fork', function (t) {
   })
 })
 
-tape('three writers, two forks', function (t) {
+tape.skip('three writers, two forks', function (t) {
   t.plan(2 * 3 + 1)
 
   var replicate = require('./helpers/replicate')
@@ -333,7 +333,7 @@ tape('three writers, two forks', function (t) {
   })
 })
 
-tape('list buffers an iterator', function (t) {
+tape.skip('list buffers an iterator', function (t) {
   var db = create.one()
 
   put(db, ['a', 'b', 'b/c'], function (err) {

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -3,200 +3,190 @@ var create = require('./helpers/create')
 var put = require('./helpers/put')
 var run = require('./helpers/run')
 
-tape('basic iteration', function (t) {
-  var db = create.one()
-  var vals = ['a', 'b', 'c']
-  var expected = toMap(vals)
+runIteratorSuite({ lexint: false })
+runIteratorSuite({ lexint: true })
 
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator(), function (err, map) {
+function runIteratorSuite (opts) {
+  var tag = '(' + (opts.lexint ? 'lexint' : 'hash') + ') '
+  tape(tag + 'basic iteration', function (t) {
+    var db = create.one(null, opts)
+    var vals = ['a', 'b', 'c']
+    var expected = toMap(vals)
+
+    put(db, vals, function (err) {
       t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('iterate a big db', function (t) {
-  var db = create.one()
-
-  var vals = range(1000, '#')
-  var expected = toMap(vals)
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator(), function (err, map) {
-      t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('prefix basic iteration', function (t) {
-  var db = create.one()
-  var vals = ['foo/a', 'foo/b', 'foo/c']
-  var expected = toMap(vals)
-
-  vals = vals.concat(['a', 'b', 'c'])
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator('foo'), function (err, map) {
-      t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('empty prefix iteration', function (t) {
-  var db = create.one()
-  var vals = ['foo/a', 'foo/b', 'foo/c']
-  var expected = {}
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator('bar'), function (err, map) {
-      t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('prefix iterate a big db', function (t) {
-  var db = create.one()
-
-  var vals = range(1000, 'foo/#')
-  var expected = toMap(vals)
-
-  vals = vals.concat(range(1000, '#'))
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator('foo'), function (err, map) {
-      t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('non recursive iteration', function (t) {
-  var db = create.one()
-
-  var vals = [
-    'a',
-    'a/b/c/d',
-    'a/c',
-    'b',
-    'b/b/c',
-    'c/a',
-    'c'
-  ]
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator({recursive: false}), function (err, map) {
-      t.error(err, 'no error')
-      var keys = Object.keys(map).map(k => k.split('/')[0])
-      t.same(keys.sort(), ['a', 'b', 'c'], 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('mixed nested and non nexted iteration', function (t) {
-  var db = create.one()
-  var vals = ['a', 'a/a', 'a/b', 'a/c', 'a/a/a', 'a/a/b', 'a/a/c']
-  var expected = toMap(vals)
-
-  put(db, vals, function (err) {
-    t.error(err, 'no error')
-    all(db.iterator(), function (err, map) {
-      t.error(err, 'no error')
-      t.same(map, expected, 'iterated all values')
-      t.end()
-    })
-  })
-})
-
-tape('two writers, simple fork', function (t) {
-  t.plan(2 * 2 + 1)
-
-  create.two(function (db1, db2, replicate) {
-    run(
-      cb => db1.put('0', '0', cb),
-      replicate,
-      cb => db1.put('1', '1a', cb),
-      cb => db2.put('1', '1b', cb),
-      cb => db1.put('10', '10', cb),
-      replicate,
-      cb => db1.put('2', '2', cb),
-      cb => db1.put('1/0', '1/0', cb),
-      done
-    )
-
-    function done (err) {
-      t.error(err, 'no error')
-      all(db1.iterator(), ondb1all)
-      all(db2.iterator(), ondb2all)
-    }
-
-    function ondb2all (err, map) {
-      t.error(err, 'no error')
-      t.same(map, {'0': ['0'], '1': ['1a', '1b'], '10': ['10']})
-    }
-
-    function ondb1all (err, map) {
-      t.error(err, 'no error')
-      t.same(map, {'0': ['0'], '1': ['1a', '1b'], '10': ['10'], '2': ['2'], '1/0': ['1/0']})
-    }
-  })
-})
-
-tape('two writers, one fork', function (t) {
-  create.two(function (db1, db2, replicate) {
-    run(
-      cb => db1.put('0', '0', cb),
-      cb => db2.put('2', '2', cb),
-      cb => db2.put('3', '3', cb),
-      cb => db2.put('4', '4', cb),
-      cb => db2.put('5', '5', cb),
-      cb => db2.put('6', '6', cb),
-      cb => db2.put('7', '7', cb),
-      cb => db2.put('8', '8', cb),
-      cb => db2.put('9', '9', cb),
-      cb => replicate(cb),
-      cb => db1.put('1', '1a', cb),
-      cb => db2.put('1', '1b', cb),
-      cb => replicate(cb),
-      cb => db1.put('0', '00', cb),
-      cb => replicate(cb),
-      cb => db2.put('hi', 'ho', cb),
-      done
-    )
-
-    function done (err) {
-      t.error(err, 'no error')
-      all(db1.iterator(), function (err, vals) {
+      all(db.iterator(), function (err, map) {
         t.error(err, 'no error')
-        t.same(vals, {
-          '0': ['00'],
-          '1': ['1a', '1b'],
-          '2': ['2'],
-          '3': ['3'],
-          '4': ['4'],
-          '5': ['5'],
-          '6': ['6'],
-          '7': ['7'],
-          '8': ['8'],
-          '9': ['9']
-        })
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
 
-        all(db2.iterator(), function (err, vals) {
+  tape(tag + 'iterate a big db', function (t) {
+    var db = create.one(null, opts)
+
+    var vals = range(1000, '#')
+    var expected = toMap(vals)
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator(), function (err, map) {
+        t.error(err, 'no error')
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'prefix basic iteration', function (t) {
+    var db = create.one(null, opts)
+    var vals = ['foo/a', 'foo/b', 'foo/c']
+    var expected = toMap(vals)
+
+    vals = vals.concat(['a', 'b', 'c'])
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator('foo'), function (err, map) {
+        t.error(err, 'no error')
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'empty prefix iteration', function (t) {
+    var db = create.one(null, opts)
+    var vals = ['foo/a', 'foo/b', 'foo/c']
+    var expected = {}
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator('bar'), function (err, map) {
+        t.error(err, 'no error')
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'prefix iterate a big db', function (t) {
+    var db = create.one(null, opts)
+
+    var vals = range(1000, 'foo/#')
+    var expected = toMap(vals)
+
+    vals = vals.concat(range(1000, '#'))
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator('foo'), function (err, map) {
+        t.error(err, 'no error')
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'non recursive iteration', function (t) {
+    var db = create.one(null, opts)
+
+    var vals = [
+      'a',
+      'a/b/c/d',
+      'a/c',
+      'b',
+      'b/b/c',
+      'c/a',
+      'c'
+    ]
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator({recursive: false}), function (err, map) {
+        t.error(err, 'no error')
+        var keys = Object.keys(map).map(k => k.split('/')[0])
+        t.same(keys.sort(), ['a', 'b', 'c'], 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'mixed nested and non nexted iteration', function (t) {
+    var db = create.one(null, opts)
+    var vals = ['a', 'a/a', 'a/b', 'a/c', 'a/a/a', 'a/a/b', 'a/a/c']
+    var expected = toMap(vals)
+
+    put(db, vals, function (err) {
+      t.error(err, 'no error')
+      all(db.iterator(), function (err, map) {
+        t.error(err, 'no error')
+        t.same(map, expected, 'iterated all values')
+        t.end()
+      })
+    })
+  })
+
+  tape(tag + 'two writers, simple fork', function (t) {
+    t.plan(2 * 2 + 1)
+
+    create.two(opts, function (db1, db2, replicate) {
+      run(
+        cb => db1.put('0', '0', cb),
+        replicate,
+        cb => db1.put('1', '1a', cb),
+        cb => db2.put('1', '1b', cb),
+        cb => db1.put('10', '10', cb),
+        replicate,
+        cb => db1.put('2', '2', cb),
+        cb => db1.put('1/0', '1/0', cb),
+        done
+      )
+
+      function done (err) {
+        t.error(err, 'no error')
+        all(db1.iterator(), ondb1all)
+        all(db2.iterator(), ondb2all)
+      }
+
+      function ondb2all (err, map) {
+        t.error(err, 'no error')
+        t.same(map, {'0': ['0'], '1': ['1a', '1b'], '10': ['10']})
+      }
+
+      function ondb1all (err, map) {
+        t.error(err, 'no error')
+        t.same(map, {'0': ['0'], '1': ['1a', '1b'], '10': ['10'], '2': ['2'], '1/0': ['1/0']})
+      }
+    })
+  })
+
+  tape(tag + 'two writers, one fork', function (t) {
+    create.two(opts, function (db1, db2, replicate) {
+      run(
+        cb => db1.put('0', '0', cb),
+        cb => db2.put('2', '2', cb),
+        cb => db2.put('3', '3', cb),
+        cb => db2.put('4', '4', cb),
+        cb => db2.put('5', '5', cb),
+        cb => db2.put('6', '6', cb),
+        cb => db2.put('7', '7', cb),
+        cb => db2.put('8', '8', cb),
+        cb => db2.put('9', '9', cb),
+        cb => replicate(cb),
+        cb => db1.put('1', '1a', cb),
+        cb => db2.put('1', '1b', cb),
+        cb => replicate(cb),
+        cb => db1.put('0', '00', cb),
+        cb => replicate(cb),
+        cb => db2.put('hi', 'ho', cb),
+        done
+      )
+
+      function done (err) {
+        t.error(err, 'no error')
+        all(db1.iterator(), function (err, vals) {
           t.error(err, 'no error')
           t.same(vals, {
             '0': ['00'],
@@ -208,148 +198,164 @@ tape('two writers, one fork', function (t) {
             '6': ['6'],
             '7': ['7'],
             '8': ['8'],
-            '9': ['9'],
-            'hi': ['ho']
+            '9': ['9']
           })
-          t.end()
+
+          all(db2.iterator(), function (err, vals) {
+            t.error(err, 'no error')
+            t.same(vals, {
+              '0': ['00'],
+              '1': ['1a', '1b'],
+              '2': ['2'],
+              '3': ['3'],
+              '4': ['4'],
+              '5': ['5'],
+              '6': ['6'],
+              '7': ['7'],
+              '8': ['8'],
+              '9': ['9'],
+              'hi': ['ho']
+            })
+            t.end()
+          })
         })
-      })
-    }
-  })
-})
-
-tape('two writers, one fork, many values', function (t) {
-  var r = range(100, 'i')
-
-  create.two(function (db1, db2, replicate) {
-    run(
-      cb => db1.put('0', '0', cb),
-      cb => db2.put('2', '2', cb),
-      cb => db2.put('3', '3', cb),
-      cb => db2.put('4', '4', cb),
-      cb => db2.put('5', '5', cb),
-      cb => db2.put('6', '6', cb),
-      cb => db2.put('7', '7', cb),
-      cb => db2.put('8', '8', cb),
-      cb => db2.put('9', '9', cb),
-      cb => replicate(cb),
-      cb => db1.put('1', '1a', cb),
-      cb => db2.put('1', '1b', cb),
-      cb => replicate(cb),
-      cb => db1.put('0', '00', cb),
-      r.map(i => cb => db1.put(i, i, cb)),
-      cb => replicate(cb),
-      done
-    )
-
-    function done (err) {
-      t.error(err, 'no error')
-
-      var expected = {
-        '0': ['00'],
-        '1': ['1a', '1b'],
-        '2': ['2'],
-        '3': ['3'],
-        '4': ['4'],
-        '5': ['5'],
-        '6': ['6'],
-        '7': ['7'],
-        '8': ['8'],
-        '9': ['9']
       }
+    })
+  })
 
-      r.forEach(function (v) {
-        expected[v] = [v]
-      })
+  tape(tag + 'two writers, one fork, many values', function (t) {
+    var r = range(100, 'i')
 
-      all(db1.iterator(), function (err, vals) {
+    create.two(opts, function (db1, db2, replicate) {
+      run(
+        cb => db1.put('0', '0', cb),
+        cb => db2.put('2', '2', cb),
+        cb => db2.put('3', '3', cb),
+        cb => db2.put('4', '4', cb),
+        cb => db2.put('5', '5', cb),
+        cb => db2.put('6', '6', cb),
+        cb => db2.put('7', '7', cb),
+        cb => db2.put('8', '8', cb),
+        cb => db2.put('9', '9', cb),
+        cb => replicate(cb),
+        cb => db1.put('1', '1a', cb),
+        cb => db2.put('1', '1b', cb),
+        cb => replicate(cb),
+        cb => db1.put('0', '00', cb),
+        r.map(i => cb => db1.put(i, i, cb)),
+        cb => replicate(cb),
+        done
+      )
+
+      function done (err) {
         t.error(err, 'no error')
-        t.same(vals, expected)
-        all(db2.iterator(), function (err, vals) {
+
+        var expected = {
+          '0': ['00'],
+          '1': ['1a', '1b'],
+          '2': ['2'],
+          '3': ['3'],
+          '4': ['4'],
+          '5': ['5'],
+          '6': ['6'],
+          '7': ['7'],
+          '8': ['8'],
+          '9': ['9']
+        }
+
+        r.forEach(function (v) {
+          expected[v] = [v]
+        })
+
+        all(db1.iterator(), function (err, vals) {
           t.error(err, 'no error')
           t.same(vals, expected)
+          all(db2.iterator(), function (err, vals) {
+            t.error(err, 'no error')
+            t.same(vals, expected)
+            t.end()
+          })
+        })
+      }
+    })
+  })
+
+  tape(tag + 'two writers, fork', function (t) {
+    t.plan(2 * 2 + 1)
+
+    create.two(opts, function (a, b, replicate) {
+      run(
+        cb => a.put('a', 'a', cb),
+        replicate,
+        cb => b.put('a', 'b', cb),
+        cb => a.put('b', 'c', cb),
+        replicate,
+        done
+      )
+
+      function done (err) {
+        t.error(err, 'no error')
+
+        all(a.iterator(), onall)
+        all(b.iterator(), onall)
+
+        function onall (err, map) {
+          t.error(err, 'no error')
+          t.same(map, {b: ['c'], a: ['b']})
+        }
+      }
+    })
+  })
+
+  tape(tag + 'three writers, two forks', function (t) {
+    t.plan(2 * 3 + 1)
+
+    var replicate = require('./helpers/replicate')
+
+    create.three(opts, function (a, b, c, replicateAll) {
+      run(
+        cb => a.put('a', 'a', cb),
+        replicateAll,
+        cb => b.put('a', 'ab', cb),
+        cb => a.put('some', 'some', cb),
+        cb => replicate(a, c, cb),
+        cb => c.put('c', 'c', cb),
+        replicateAll,
+        done
+      )
+
+      function done (err) {
+        t.error(err, 'no error')
+        all(a.iterator(), onall)
+        all(b.iterator(), onall)
+        all(c.iterator(), onall)
+
+        function onall (err, map) {
+          t.error(err, 'no error')
+          t.same(map, {a: ['ab'], c: ['c'], some: ['some']})
+        }
+      }
+    })
+  })
+
+  tape(tag + 'list buffers an iterator', function (t) {
+    var db = create.one(null, opts)
+
+    put(db, ['a', 'b', 'b/c'], function (err) {
+      t.error(err, 'no error')
+      db.list(function (err, all) {
+        t.error(err, 'no error')
+        t.same(all.map(v => v.key).sort(), ['a', 'b', 'b/c'])
+        db.list('b', {gt: true}, function (err, all) {
+          t.error(err, 'no error')
+          t.same(all.length, 1)
+          t.same(all[0].key, 'b/c')
           t.end()
         })
-      })
-    }
-  })
-})
-
-tape('two writers, fork', function (t) {
-  t.plan(2 * 2 + 1)
-
-  create.two(function (a, b, replicate) {
-    run(
-      cb => a.put('a', 'a', cb),
-      replicate,
-      cb => b.put('a', 'b', cb),
-      cb => a.put('b', 'c', cb),
-      replicate,
-      done
-    )
-
-    function done (err) {
-      t.error(err, 'no error')
-
-      all(a.iterator(), onall)
-      all(b.iterator(), onall)
-
-      function onall (err, map) {
-        t.error(err, 'no error')
-        t.same(map, {b: ['c'], a: ['b']})
-      }
-    }
-  })
-})
-
-tape('three writers, two forks', function (t) {
-  t.plan(2 * 3 + 1)
-
-  var replicate = require('./helpers/replicate')
-
-  create.three(function (a, b, c, replicateAll) {
-    run(
-      cb => a.put('a', 'a', cb),
-      replicateAll,
-      cb => b.put('a', 'ab', cb),
-      cb => a.put('some', 'some', cb),
-      cb => replicate(a, c, cb),
-      cb => c.put('c', 'c', cb),
-      replicateAll,
-      done
-    )
-
-    function done (err) {
-      t.error(err, 'no error')
-      all(a.iterator(), onall)
-      all(b.iterator(), onall)
-      all(c.iterator(), onall)
-
-      function onall (err, map) {
-        t.error(err, 'no error')
-        t.same(map, {a: ['ab'], c: ['c'], some: ['some']})
-      }
-    }
-  })
-})
-
-tape('list buffers an iterator', function (t) {
-  var db = create.one()
-
-  put(db, ['a', 'b', 'b/c'], function (err) {
-    t.error(err, 'no error')
-    db.list(function (err, all) {
-      t.error(err, 'no error')
-      t.same(all.map(v => v.key).sort(), ['a', 'b', 'b/c'])
-      db.list('b', {gt: true}, function (err, all) {
-        t.error(err, 'no error')
-        t.same(all.length, 1)
-        t.same(all[0].key, 'b/c')
-        t.end()
       })
     })
   })
-})
+}
 
 function range (n, v) {
   // #0, #1, #2, ...

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -84,7 +84,7 @@ tape('prefix iterate a big db', function (t) {
   })
 })
 
-tape.skip('non recursive iteration', function (t) {
+tape('non recursive iteration', function (t) {
   var db = create.one()
 
   var vals = [
@@ -108,7 +108,7 @@ tape.skip('non recursive iteration', function (t) {
   })
 })
 
-tape.skip('mixed nested and non nexted iteration', function (t) {
+tape('mixed nested and non nexted iteration', function (t) {
   var db = create.one()
   var vals = ['a', 'a/a', 'a/b', 'a/c', 'a/a/a', 'a/a/b', 'a/a/c']
   var expected = toMap(vals)
@@ -123,7 +123,7 @@ tape.skip('mixed nested and non nexted iteration', function (t) {
   })
 })
 
-tape.skip('two writers, simple fork', function (t) {
+tape('two writers, simple fork', function (t) {
   t.plan(2 * 2 + 1)
 
   create.two(function (db1, db2, replicate) {
@@ -157,7 +157,7 @@ tape.skip('two writers, simple fork', function (t) {
   })
 })
 
-tape.skip('two writers, one fork', function (t) {
+tape('two writers, one fork', function (t) {
   create.two(function (db1, db2, replicate) {
     run(
       cb => db1.put('0', '0', cb),
@@ -218,7 +218,7 @@ tape.skip('two writers, one fork', function (t) {
   })
 })
 
-tape.skip('two writers, one fork, many values', function (t) {
+tape('two writers, one fork, many values', function (t) {
   var r = range(100, 'i')
 
   create.two(function (db1, db2, replicate) {
@@ -275,7 +275,7 @@ tape.skip('two writers, one fork, many values', function (t) {
   })
 })
 
-tape.skip('two writers, fork', function (t) {
+tape('two writers, fork', function (t) {
   t.plan(2 * 2 + 1)
 
   create.two(function (a, b, replicate) {
@@ -302,7 +302,7 @@ tape.skip('two writers, fork', function (t) {
   })
 })
 
-tape.skip('three writers, two forks', function (t) {
+tape('three writers, two forks', function (t) {
   t.plan(2 * 3 + 1)
 
   var replicate = require('./helpers/replicate')
@@ -333,7 +333,7 @@ tape.skip('three writers, two forks', function (t) {
   })
 })
 
-tape.skip('list buffers an iterator', function (t) {
+tape('list buffers an iterator', function (t) {
   var db = create.one()
 
   put(db, ['a', 'b', 'b/c'], function (err) {


### PR DESCRIPTION
This PR includes a couple of changes to make lexicographic iteration possible (relevant discussion here https://github.com/mafintosh/hyperdb/issues/78). Once supported, we should be able to create useful things like a leveldown implementation based on hyperdb.

Summary of changes:
1. The approach to path construction in `lib/hash.js` has been modified to support variable-length paths. Each path component is separated by a separator value instead of being fixed-length.
2. `lib/iterator.js` and `lib/put.js` have been lightly modified to a) remove hard-coded values and b) make non-recursive iteration respect the path separator. 

Some things to consider before this can be merged:
1. The hashing scheme for path components should probably be configurable, but the variable-length path approach works regardless of hashing scheme (i.e. for lexint, you don't want to hash the path, but if you don't need lex iteration then you'll likely want to get the benefits that come with the hash-based approach).
2.  The hashing scheme will need to be included in a metadata record (TBD), since if affects lookups -- replication between two dbs with different schemes would be problematic, for example.

*Note: This is still WIP, and the above issues need to be addressed before merging.*