### PR TITLE
When new content feeds are adding, check them all in replication

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ HyperDB.prototype.replicate = function (opts) {
     if (stream.destroyed) return
 
     var i = 0
-    var j = 0
+    var replicatingContentFeeds = []
 
     self._replicating.push(replicate)
     stream.on('close', onclose)
@@ -327,9 +327,12 @@ HyperDB.prototype.replicate = function (opts) {
 
       if (!self.contentFeeds) return
 
-      for (; j < self.contentFeeds.length; j++) {
-        if (!self.contentFeeds[j]) return
-        self.contentFeeds[j].replicate(opts)
+      for (var j = 0; j < self.contentFeeds.length; j++) {
+        if (!replicatingContentFeeds[j]) {
+          if (!self.contentFeeds[j]) continue
+          self.contentFeeds[j].replicate(opts)
+          replicatingContentFeeds[j] = true
+        }
       }
     }
 
@@ -452,6 +455,10 @@ HyperDB.prototype._pushWriter = function (writer) {
 
   if (!this.opened) return
 
+  this._updateReplicating()
+}
+
+HyperDB.prototype._updateReplicating = function () {
   for (var i = 0; i < this._replicating.length; i++) {
     this._replicating[i]()
   }
@@ -811,7 +818,10 @@ Writer.prototype._ensureContentFeed = function (key) {
     secretKey
   })
 
-  if (this._db.contentFeeds) this._db.contentFeeds[this._id] = this._contentFeed
+  if (this._db.contentFeeds) {
+    this._db.contentFeeds[this._id] = this._contentFeed
+    this._db._updateReplicating()
+  }
 
   function storage (name) {
     return self._db._contentStorage('content/' + self._feed.discoveryKey.toString('hex') + '/' + name)
@@ -823,9 +833,7 @@ Writer.prototype._updateFeeds = function () {
 
   if (this._feedsMessage.contentFeed && this._db.contentFeeds && !this._contentFeed) {
     this._ensureContentFeed(this._feedsMessage.contentFeed)
-    for (i = 0; i < this._db._replicating.length; i++) {
-      this._db._replicating[i]()
-    }
+    this._db._updateReplicating()
   }
 
   var writers = this._feedsMessage.feeds || []


### PR DESCRIPTION
When new content feeds are adding, check them all in the replication function.

The previous logic wouldn't check old feeds that were updated with content feeds, and would return early when there was an entry with no content feed.

I also created a ._updateReplicating() method to save repeating the logic that re-calls the replicating functions.