### PR TITLE
Add reverse option to iterator

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -22,6 +22,7 @@ function Iterator (db, prefix, opts) {
   }]
 
   this._recursive = opts.recursive !== false
+  this._reverse = !!opts.reverse
   this._gt = !!opts.gt
   this._start = this._stack[0].path.length
   this._end = this._recursive ? Infinity : this._start + hash.LENGTH
@@ -132,7 +133,7 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
 Iterator.prototype._filterResult = function (nodes, i) {
   var result = null
 
-  nodes.sort(byKey)
+  nodes.sort(byKey, this._reverse)
 
   for (var j = 0; j < nodes.length; j++) {
     var node = nodes[j]
@@ -187,11 +188,13 @@ Iterator.prototype._prereturn = function (nodes) {
 
 Iterator.prototype._sortOrder = function (i) {
   var gt = this._gt || !this._start
-  return gt && this._start === i ? SORT_GT : SORT_GTE
+  var order = gt && this._start === i ? SORT_GT : SORT_GTE
+  return this._reverse ? order.reverse() : order
 }
 
-function byKey (a, b) {
+function byKey (a, b, reverse) {
   var k = b.key.localeCompare(a.key)
+  if (reverse) k = -1 * k
   return k || b.feed - a.feed
 }
 

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -198,8 +198,7 @@ Iterator.prototype._sortOrder = function (i) {
 
 function byKey (a, b, reverse) {
   var k = b.key.localeCompare(a.key)
-  if (reverse) k = -1 * k
-  return k || b.feed - a.feed
+  return (reverse ? -1 : 1) * (k || b.feed - a.feed)
 }
 
 function allDeletes (nodes) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -23,6 +23,11 @@ function Iterator (db, prefix, opts) {
 
   this._recursive = opts.recursive !== false
   this._reverse = !!opts.reverse
+  this._order = {
+    gt: this._reverse ? SORT_GT.slice().reverse() : SORT_GT,
+    gte: this._reverse ? SORT_GTE.slice().reverse() : SORT_GTE
+  }
+
   this._gt = !!opts.gt
   this._start = this._stack[0].path.length
   this._end = this._recursive ? Infinity : this._start + hash.LENGTH
@@ -188,8 +193,7 @@ Iterator.prototype._prereturn = function (nodes) {
 
 Iterator.prototype._sortOrder = function (i) {
   var gt = this._gt || !this._start
-  var order = gt && this._start === i ? SORT_GT : SORT_GTE
-  return this._reverse ? order.slice().reverse() : order
+  return gt && this._start === i ? this._order.gt : this._order.gte
 }
 
 function byKey (a, b, reverse) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -189,7 +189,7 @@ Iterator.prototype._prereturn = function (nodes) {
 Iterator.prototype._sortOrder = function (i) {
   var gt = this._gt || !this._start
   var order = gt && this._start === i ? SORT_GT : SORT_GTE
-  return this._reverse ? order.reverse() : order
+  return this._reverse ? order.slice().reverse() : order
 }
 
 function byKey (a, b, reverse) {

--- a/test/iterator-order.js
+++ b/test/iterator-order.js
@@ -107,7 +107,6 @@ function testTwoFeedsWithKeys (t, keys, opts, cb) {
 
 function testIteratorOrder (t, iterator, expected, sortFunc, done) {
   var sorted = expected.slice(0).sort(sortFunc)
-  console.log('sorted:', sorted)
   each(iterator, onEach, onDone)
   function onEach (err, node) {
     t.error(err, 'no error')

--- a/test/iterator-order.js
+++ b/test/iterator-order.js
@@ -10,6 +10,10 @@ function sortByHash (a, b) {
   return ha.localeCompare(hb)
 }
 
+function reverseSortByHash (a, b) {
+  return -1 * sortByHash(a, b)
+}
+
 const cases = {
   'simple': ['a', 'b', 'c'],
   'mixed depth from root': ['a/a', 'a/b', 'a/c', 'b', 'c'],
@@ -22,6 +26,8 @@ Object.keys(cases).forEach((key) => {
     run(
       cb => testSingleFeedWithKeys(t, keysToTest, cb),
       cb => testTwoFeedsWithKeys(t, keysToTest, cb),
+      cb => testSingleFeedWithKeys(t, keysToTest, { reverse: true, sort: reverseSortByHash }, cb),
+      cb => testTwoFeedsWithKeys(t, keysToTest, { reverse: true, sort: reverseSortByHash }, cb),
       cb => t.end()
     )
   })
@@ -61,16 +67,26 @@ tape('fully visit a folder before visiting the next one', function (t) {
   })
 })
 
-function testSingleFeedWithKeys (t, keys, cb) {
+function testSingleFeedWithKeys (t, keys, opts, cb) {
+  if (typeof opts === 'function') return testSingleFeedWithKeys(t, keys, null, opts)
+  opts = opts || {}
+
+  var sortFunc = opts.sort || sortByHash
+
   t.comment('with single feed')
   var db = create.one()
   put(db, keys, function (err) {
     t.error(err, 'no error')
-    testIteratorOrder(t, db.iterator(), keys, cb)
+    testIteratorOrder(t, db.iterator(opts), keys, sortFunc, cb)
   })
 }
 
-function testTwoFeedsWithKeys (t, keys, cb) {
+function testTwoFeedsWithKeys (t, keys, opts, cb) {
+  if (typeof opts === 'function') return testTwoFeedsWithKeys(t, keys, null, opts)
+  opts = opts || {}
+
+  var sortFunc = opts.sort || sortByHash
+
   t.comment('with values split across two feeds')
   create.two(function (db1, db2, replicate) {
     var half = Math.floor(keys.length / 2)
@@ -78,8 +94,8 @@ function testTwoFeedsWithKeys (t, keys, cb) {
       cb => put(db1, keys.slice(0, half), cb),
       cb => put(db2, keys.slice(half), cb),
       cb => replicate(cb),
-      cb => testIteratorOrder(t, db1.iterator(), keys, cb),
-      cb => testIteratorOrder(t, db2.iterator(), keys, cb),
+      cb => testIteratorOrder(t, db1.iterator(opts), keys, sortFunc, cb),
+      cb => testIteratorOrder(t, db2.iterator(opts), keys, sortFunc, cb),
       done
     )
   })
@@ -89,8 +105,9 @@ function testTwoFeedsWithKeys (t, keys, cb) {
   }
 }
 
-function testIteratorOrder (t, iterator, expected, done) {
-  var sorted = expected.slice(0).sort(sortByHash)
+function testIteratorOrder (t, iterator, expected, sortFunc, done) {
+  var sorted = expected.slice(0).sort(sortFunc)
+  console.log('sorted:', sorted)
   each(iterator, onEach, onDone)
   function onEach (err, node) {
     t.error(err, 'no error')


### PR DESCRIPTION
By reversing the sort order in iterator, we can efficiently iterate over results in descending hash order. This option will be necessary for a leveldown implementation. Implements #107 

This PR:
1. Adds the `reverse` option to iterator
2. Duplicates the tests in `iterator-order.js` to test for reverse iteration.