### PR TITLE
Rename call to non-existent ._destroy() method to .destroy()

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -60,7 +60,7 @@ function sortByFeed (a, b) {
 }
 
 function onkick (err, nodes) {
-  if (err) return this._destroy(err)
+  if (err) return this.destroy(err)
 
   var kicked = this._kicked
 


### PR DESCRIPTION
I was getting an exception:

/app/node_modules/hyperdb/lib/watch.js:63

  if (err) return this._destroy(err)

                       ^

TypeError: this._destroy is not a function

    at Watcher.onkick (/app/node_modules/hyperdb/lib/watch.js:63:24)