### PR TITLE
Document `key` and `discoveryKey` fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ Options include:
 }
 ```
 
+#### `db.key`
+
+Buffer containing the public key identifying this hyperdb.
+
+Populated after `ready` has been emitted. May be `null` before the event.
+
+#### `db.discoveryKey`
+
+Buffer containing a key derived from the db.key.
+In contrast to `db.key` this key does not allow you to verify the data but can be used to announce or look for peers that are sharing the same hyperdb, without leaking the hyperdb key.
+
+Populated after `ready` has been emitted. May be `null` before the event.
+
 #### `db.on('ready')`
 
 Emitted exactly once: when the db is fully ready and all static properties have


### PR DESCRIPTION
I observed from the source these have the same function as in hypercore, and copied the documentation over.

A number of fields are remaining to be documented, such as `source`, `local`, `localContent`, `feeds`, `contentFeeds`, `id`
