### PR TITLE
Replication fixes with 3 writers

### DIFF
--- a/index.js
+++ b/index.js
@@ -732,9 +732,13 @@ Writer.prototype._needsInflate = function () {
 
 Writer.prototype._maybeUpdateFeeds = function () {
   if (!this._feedsMessage) return
-  if (this._decodeMap.length === this._db.feeds.length) return
-  if (this._encodeMap.length === this._db.feeds.length) return
-  this._updateFeeds()
+  var writers = this._feedsMessage.feeds || []
+  if (
+    this._decodeMap.length !== writers.length ||
+    this._encodeMap.length !== this._db.feeds.length
+  ) {
+    this._updateFeeds()
+  }
 }
 
 Writer.prototype._decode = function (seq, buf, cb) {

--- a/test/watch.js
+++ b/test/watch.js
@@ -1,6 +1,7 @@
 var tape = require('tape')
 var create = require('./helpers/create')
 var replicate = require('./helpers/replicate')
+var run = require('./helpers/run')
 
 tape('basic watch', function (t) {
   var db = create.one()
@@ -76,6 +77,34 @@ tape('remote watch', function (t) {
       })
 
       replicate(db, clone)
+    })
+  })
+})
+
+tape('watch with 3rd-party authorize', function (t) {
+  create.two(function (a, b) {
+    t.plan(2)
+
+    a.watch(function () {
+      t.pass('watch called')
+    })
+
+    var c = create.one(a.key)
+    c.ready(function () {
+      run(
+        cb => replicate(a, b, cb),
+        cb => replicate(b, c, cb),
+        cb => b.authorize(c.local.key, cb),
+        cb => replicate(b, c, cb),
+        cb => c.put('hello2', 'world2', cb),
+        cb => replicate(b, c, cb),
+        cb => replicate(a, b, cb),
+        done
+      )
+
+      function done (err) {
+        t.error(err, 'no error')
+      }
     })
   })
 })


### PR DESCRIPTION
Added a .watch() test for a 3 writer scenario where the third
writer joins after the .watch() is started.

Update the logic for _maybeUpdateFeeds to avoid 'Missing feed mappings'
assertions.