### PR TITLE
cleanup waitForUpdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,9 +253,7 @@ HyperDB.prototype.heads = function (cb) {
 }
 
 HyperDB.prototype._waitForUpdate = function () {
-  return this._replicating.length &&
-    !this._writers[0].length() &&
-    this.local !== this.source
+  return !this._writers[0].length() && !this.local.length
 }
 
 HyperDB.prototype._index = function (key) {


### PR DESCRIPTION
Since we added the protocol header it's a bit easier to reason about. This makes operations wait if no data has been written to the source feed or your local feed.