### PR TITLE
Support for putting/getting null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ HyperDB.prototype.batch = function (batch, cb) {
   })
 }
 
-HyperDB.prototype.put = function (key, val, cb) {
+HyperDB.prototype.put = function (key, val, opts, cb) {
+  if (typeof opts === 'function') return this.put(key, val, null, opts)
   if (!cb) cb = noop
 
   if (this._checkout) {
@@ -144,7 +145,7 @@ HyperDB.prototype.put = function (key, val, cb) {
     var clock = self._clock()
     self.heads(function (err, heads) {
       if (err) return unlock(err)
-      put(self, clock, heads, key, val, unlock)
+      put(self, clock, heads, key, val, opts, unlock)
     })
 
     function unlock (err, node) {
@@ -154,7 +155,7 @@ HyperDB.prototype.put = function (key, val, cb) {
 }
 
 HyperDB.prototype.del = function (key, cb) {
-  this.put(key, null, cb)
+  this.put(key, null, { delete: true }, cb)
 }
 
 HyperDB.prototype.watch = function (key, cb) {

--- a/lib/put.js
+++ b/lib/put.js
@@ -2,14 +2,16 @@ var hash = require('./hash')
 
 module.exports = put
 
-function put (db, clock, heads, key, value, cb) {
-  var req = new PutRequest(db, key, value, clock)
+function put (db, clock, heads, key, value, opts, cb) {
+  if (typeof opts === 'function') return put(db, clock, heads, key, value, null, opts)
+  var req = new PutRequest(db, key, value, clock, opts)
   req.start(heads, cb)
 }
 
-function PutRequest (db, key, value, clock) {
+function PutRequest (db, key, value, clock, opts) {
   this.key = key
   this.value = value
+  this.delete = opts && opts.delete
 
   this._clock = clock
   this._active = 0
@@ -44,8 +46,7 @@ PutRequest.prototype._finalize = function () {
     clock: this._clock
   }
 
-  // TODO: allow to set this flag explicitly
-  if (node.value === null) node.deleted = true
+  if (this.delete) node.deleted = true
 
   this._db._localWriter.append(node, function (err) {
     if (err) return cb(err)

--- a/lib/put.js
+++ b/lib/put.js
@@ -11,7 +11,7 @@ function put (db, clock, heads, key, value, opts, cb) {
 function PutRequest (db, key, value, clock, opts) {
   this.key = key
   this.value = value
-  this.delete = opts && opts.delete
+  this.delete = !!(opts && opts.delete)
 
   this._clock = clock
   this._active = 0

--- a/test/basic.js
+++ b/test/basic.js
@@ -474,3 +474,16 @@ tape('can insert falsy values', function (t) {
     })
   })
 })
+
+tape('can put/get a null value', function (t) {
+  t.plan(3)
+
+  var db = create.one(null, {valueEncoding: 'json'})
+  db.put('some key', null, function (err) {
+    t.error(err, 'no error')
+    db.get('some key', function (err, node) {
+      t.error(err, 'no error')
+      t.same(node.value, null)
+    })
+  })
+})


### PR DESCRIPTION
With the change in https://github.com/mafintosh/hyperdb/pull/122, deletes are no longer represented by a `null` value, meaning nodes can have arbitrary values and still be considered deletions.

This PR makes `null` an acceptable value for `put`/`get`.

Summary of changes:
1. Added options to `put`, so that you can mark a given put as a delete (`del` calls `put` under the hood).
2. Added a test for putting/getting a non-deleted node with a `null` value.