### PR TITLE
Add key history iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ current version prefixed by `prefix`.
 `left` are the nodes for a key found in the `db` and `right` are the nodes found in the `checkout`.
 If no nodes exist in the `db` for the key `left` will be `null` and vice versa.
 
-#### `var stream = db.createHistoryStream([options])`
+#### `var stream = db.createHistoryStream([key], [options])`
 
-Returns a readable stream of node objects covering all historic values since the beginning of time
+Returns a readable stream of node objects covering all historic values since the beginning of time. Provide `key` as the first argument to limit historic values to that key.
 
 Nodes are emitted in topographic order, meaning if value `v2` was aware of value
 `v1` at its insertion time, `v1` must be emitted before `v2`.
 
-To emit the nodes in reverse order pass `{reverse: true}` as an option.
+To emit the nodes in reverse order pass `{reverse: true}` as an option. Reverse option currently does not work when the stream is limited to a specific key.
 
 #### `var stream = db.replicate([options])`
 

--- a/README.md
+++ b/README.md
@@ -213,14 +213,20 @@ current version prefixed by `prefix`.
 `left` are the nodes for a key found in the `db` and `right` are the nodes found in the `checkout`.
 If no nodes exist in the `db` for the key `left` will be `null` and vice versa.
 
-#### `var stream = db.createHistoryStream([key], [options])`
+#### `var stream = db.createHistoryStream([options])`
 
-Returns a readable stream of node objects covering all historic values since the beginning of time. Provide `key` as the first argument to limit historic values to that key.
+Returns a readable stream of node objects covering all historic values since the beginning of time.
 
 Nodes are emitted in topographic order, meaning if value `v2` was aware of value
 `v1` at its insertion time, `v1` must be emitted before `v2`.
 
-To emit the nodes in reverse order pass `{reverse: true}` as an option. Reverse option currently does not work when the stream is limited to a specific key.
+To emit the nodes in reverse order pass `{reverse: true}` as an option.
+
+#### `var stream = db.createKeyHistoryStream(key)`
+
+Returns a readable stream of node objects covering all historic values for a specific key.
+
+Results are returned with the latest value first.
 
 #### `var stream = db.replicate([options])`
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var hash = require('./lib/hash')
 var iterator = require('./lib/iterator')
 var differ = require('./lib/differ')
 var history = require('./lib/history')
+var keyHistory = require('./lib/key-history')
 var get = require('./lib/get')
 var put = require('./lib/put')
 var messages = require('./lib/messages')
@@ -506,8 +507,12 @@ HyperDB.prototype.list = function (prefix, opts, cb) {
   }
 }
 
-HyperDB.prototype.history = function (opts) {
-  return history(this, opts)
+HyperDB.prototype.history = function (prefix, opts) {
+  if (prefix && !isOptions(prefix)) {
+    console.log('KEY')
+    return keyHistory(this, prefix, opts)
+  }
+  return history(this, prefix)
 }
 
 HyperDB.prototype.diff = function (other, prefix, opts) {
@@ -520,8 +525,8 @@ HyperDB.prototype.iterator = function (prefix, opts) {
   return iterator(this, normalizeKey(prefix || ''), opts)
 }
 
-HyperDB.prototype.createHistoryStream = function (opts) {
-  return toStream(this.history(opts))
+HyperDB.prototype.createHistoryStream = function (prefix, opts) {
+  return toStream(this.history(prefix, opts))
 }
 
 HyperDB.prototype.createDiffStream = function (other, prefix, opts) {

--- a/index.js
+++ b/index.js
@@ -507,12 +507,12 @@ HyperDB.prototype.list = function (prefix, opts, cb) {
   }
 }
 
-HyperDB.prototype.history = function (prefix, opts) {
-  if (prefix && !isOptions(prefix)) {
-    console.log('KEY')
-    return keyHistory(this, prefix, opts)
-  }
-  return history(this, prefix)
+HyperDB.prototype.history = function (opts) {
+  return history(this, opts)
+}
+
+HyperDB.prototype.keyHistory = function (prefix, opts) {
+  return keyHistory(this, prefix, opts)
 }
 
 HyperDB.prototype.diff = function (other, prefix, opts) {
@@ -525,8 +525,12 @@ HyperDB.prototype.iterator = function (prefix, opts) {
   return iterator(this, normalizeKey(prefix || ''), opts)
 }
 
-HyperDB.prototype.createHistoryStream = function (prefix, opts) {
-  return toStream(this.history(prefix, opts))
+HyperDB.prototype.createHistoryStream = function (opts) {
+  return toStream(this.history(opts))
+}
+
+HyperDB.prototype.createKeyHistoryStream = function (prefix, opts) {
+  return toStream(this.keyHistory(prefix, opts))
 }
 
 HyperDB.prototype.createDiffStream = function (other, prefix, opts) {

--- a/lib/get.js
+++ b/lib/get.js
@@ -13,7 +13,7 @@ function get (db, heads, key, opts, cb) {
 function GetRequest (db, key, opts) {
   this.key = key
   this.results = []
-
+  this._deletes = !!(opts && opts.deletes)
   this._callback = noop
   this._options = opts || null
   this._prefixed = !!(opts && opts.prefix)
@@ -88,8 +88,7 @@ GetRequest.prototype._finalize = function () {
 }
 
 GetRequest.prototype._prereturn = function (results) {
-  // TODO: the extra prefixed check should prob be it's own option, ie deletes: true
-  if (allDeletes(results) && !this._prefixed) results = []
+  if (!this._deletes && allDeletes(results) && !this._prefixed) results = []
 
   var map = options.map(this._options, this._db)
   var reduce = options.reduce(this._options, this._db)

--- a/lib/key-history.js
+++ b/lib/key-history.js
@@ -40,14 +40,14 @@ Iterator.prototype._next = function (cb) {
 
 Iterator.prototype._nextHeads = function (nodes, cb) {
   var i
-  const heads = []
-  let error = null
-  let missing = 0
+  var heads = []
+  var error = null
+  var missing = 0
 
   for (i = 0; i < nodes.length; i++) {
-    const node = nodes[i]
+    var node = nodes[i]
     for (var c = 0; c < node.clock.length; c++) {
-      const seq = node.clock[c]
+      var seq = node.clock[c]
       if (c !== node.feed && seq > 2) {
         missing++
         this._db._writers[c].get(seq - 1, onHead)

--- a/lib/key-history.js
+++ b/lib/key-history.js
@@ -1,0 +1,94 @@
+var nanoiterator = require('nanoiterator')
+var inherits = require('inherits')
+var get = require('./get')
+var normalizeKey = require('./normalize')
+
+module.exports = Iterator
+
+function Iterator (db, prefix, opts) {
+  if (!(this instanceof Iterator)) return new Iterator(db, prefix, opts)
+  nanoiterator.call(this)
+  this._db = db
+  this._prefix = normalizeKey(prefix)
+  this._heads = undefined
+}
+
+inherits(Iterator, nanoiterator)
+
+Iterator.prototype._open = function (cb) {
+  this._db.heads((err, heads) => {
+    if (err) return cb(err)
+    this._heads = heads
+    cb()
+  })
+}
+
+Iterator.prototype._next = function (cb) {
+  if (!this._heads || !this._heads.length) return cb(null, null)
+  get(this._db, this._heads, this._prefix,
+    { reduce: false, deletes: true },
+    (err, nodes) => {
+      if (err) return cb(err)
+      this._nextHeads(nodes, (err, heads) => {
+        if (err) return cb(err)
+        this._heads = heads
+        cb(null, nodes)
+      })
+    })
+}
+
+Iterator.prototype._nextHeads = function (nodes, cb) {
+  var i
+  const heads = []
+  const numFeeds = this._db.feeds.length
+  let error = null
+  let missing = 0
+
+  const feeds = []
+  for (i = 0; i < nodes.length; i++) {
+    const node = nodes[i]
+    feeds.push(node.feed)
+    if (node.seq - 1 <= 1) continue
+    missing++
+    this._db._writers[node.feed].get(node.seq - 1, onHead)
+  }
+
+  if (numFeeds !== nodes.length) {
+    const seqs = mostRecent(nodes, feeds)
+    for (i = 0; i < numFeeds; i++) {
+      const seq = seqs[i]
+      if (!seq || seq <= 1) continue
+      missing++
+      this._db._writers[i].get(seq, onHead)
+    }
+  }
+
+  if (missing === 0) cb(null, undefined)
+  function onHead (err, head) {
+    // console.log(head)
+    if (head) heads.push(head)
+    if (err) error = err
+    if (--missing) return
+    cb(error, heads)
+  }
+}
+
+function mostRecent (nodes, feeds) {
+  const seqs = []
+  for (var n = 0; n < nodes.length; n++) {
+    const trie = nodes[n].trie
+    for (var i = 0; i < trie.length; i++) {
+      const t = trie[i]
+      for (var j = 0; j < t.length; j++) {
+        const ptrs = t[j]
+        if (!ptrs) continue
+        for (var p = 0; p < ptrs.length; p++) {
+          const ptr = ptrs[p]
+          if (!ptr || feeds.includes(ptr.feed)) continue
+          if (seqs[ptr.feed] === undefined || ptr.seq > seqs[ptr.feed]) seqs[ptr.feed] = ptr.seq
+        }
+      }
+    }
+  }
+  return seqs
+}

--- a/lib/key-history.js
+++ b/lib/key-history.js
@@ -29,6 +29,7 @@ Iterator.prototype._next = function (cb) {
     { reduce: false, deletes: true },
     (err, nodes) => {
       if (err) return cb(err)
+      if (nodes.length === 0) return cb(null, null)
       this._nextHeads(nodes, (err, heads) => {
         if (err) return cb(err)
         this._heads = heads
@@ -48,7 +49,7 @@ Iterator.prototype._nextHeads = function (nodes, cb) {
   for (i = 0; i < nodes.length; i++) {
     const node = nodes[i]
     feeds.push(node.feed)
-    if (node.seq - 1 <= 1) continue
+    if (node.seq <= 1) continue
     missing++
     this._db._writers[node.feed].get(node.seq - 1, onHead)
   }
@@ -65,7 +66,6 @@ Iterator.prototype._nextHeads = function (nodes, cb) {
 
   if (missing === 0) cb(null, undefined)
   function onHead (err, head) {
-    // console.log(head)
     if (head) heads.push(head)
     if (err) error = err
     if (--missing) return

--- a/lib/key-history.js
+++ b/lib/key-history.js
@@ -41,54 +41,50 @@ Iterator.prototype._next = function (cb) {
 Iterator.prototype._nextHeads = function (nodes, cb) {
   var i
   const heads = []
-  const numFeeds = this._db.feeds.length
   let error = null
   let missing = 0
 
-  const feeds = []
   for (i = 0; i < nodes.length; i++) {
     const node = nodes[i]
-    feeds.push(node.feed)
-    if (node.seq <= 1) continue
-    missing++
-    this._db._writers[node.feed].get(node.seq - 1, onHead)
-  }
-
-  if (numFeeds !== nodes.length) {
-    const seqs = mostRecent(nodes, feeds)
-    for (i = 0; i < numFeeds; i++) {
-      const seq = seqs[i]
-      if (!seq || seq <= 1) continue
-      missing++
-      this._db._writers[i].get(seq, onHead)
+    for (var c = 0; c < node.clock.length; c++) {
+      const seq = node.clock[c]
+      if (c !== node.feed && seq > 2) {
+        missing++
+        this._db._writers[c].get(seq - 1, onHead)
+      } else if (c === node.feed && node.seq > 1) {
+        missing++
+        this._db._writers[node.feed].get(node.seq - 1, onHead)
+      }
     }
   }
-
   if (missing === 0) cb(null, undefined)
+
   function onHead (err, head) {
     if (head) heads.push(head)
     if (err) error = err
     if (--missing) return
-    cb(error, heads)
+
+    cb(error, filterHeads(heads))
   }
 }
 
-function mostRecent (nodes, feeds) {
-  const seqs = []
-  for (var n = 0; n < nodes.length; n++) {
-    const trie = nodes[n].trie
-    for (var i = 0; i < trie.length; i++) {
-      const t = trie[i]
-      for (var j = 0; j < t.length; j++) {
-        const ptrs = t[j]
-        if (!ptrs) continue
-        for (var p = 0; p < ptrs.length; p++) {
-          const ptr = ptrs[p]
-          if (!ptr || feeds.includes(ptr.feed)) continue
-          if (seqs[ptr.feed] === undefined || ptr.seq > seqs[ptr.feed]) seqs[ptr.feed] = ptr.seq
-        }
-      }
-    }
+function filterHeads (list) {
+  var heads = []
+  for (var i = 0; i < list.length; i++) {
+    if (isHead(list[i], list)) heads.push(list[i])
   }
-  return seqs
+  return heads
+}
+
+function isHead (node, list) {
+  if (!node) return false
+  var clock = node.seq + 1
+  for (var i = 0; i < list.length; i++) {
+    var other = list[i]
+    if (other === node || !other) {
+      continue
+    }
+    if ((other.clock[node.feed] || 0) >= clock) return false
+  }
+  return true
 }

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -1,11 +1,9 @@
 var tape = require('tape')
-var toStream = require('nanoiterator/to-stream')
 
 var replicate = require('./helpers/replicate')
 var create = require('./helpers/create')
 var put = require('./helpers/put')
 var run = require('./helpers/run')
-var keyHistory = require('../lib/key-history')
 
 tape('empty db', (t) => {
   var db = create.one()
@@ -120,10 +118,10 @@ tape('three feeds with all conflicting', (t) => {
 }, { timeout: 1000 })
 
 tape('three feeds (again)', (t) => {
-  const toVersion = v => ({ key: 'version', value: v })
+  var toVersion = v => ({ key: 'version', value: v })
   create.three((db1, db2, db3, replicateAll) => {
-    const len = 5
-    const expected = []
+    var len = 5
+    var expected = []
     for (var i = 0; i < len * 3; i++) {
       expected.push(i.toString())
     }
@@ -141,8 +139,8 @@ tape('three feeds (again)', (t) => {
 }, { timeout: 1000 })
 
 function testHistory (t, db, key, expected, cb) {
-  const results = expected.slice(0)
-  const stream = toStream(keyHistory(db, key))
+  var results = expected.slice(0)
+  var stream = db.createHistoryStream(key)
   stream.on('data', (data) => {
     var expected = results.shift()
     // console.log(data, expected)

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -143,7 +143,6 @@ function testHistory (t, db, key, expected, cb) {
   var stream = db.createHistoryStream(key)
   stream.on('data', (data) => {
     var expected = results.shift()
-    // console.log(data, expected)
     t.notEqual(expected, undefined)
     if (!Array.isArray(expected)) expected = [expected]
     t.same(data.length, expected.length)
@@ -152,7 +151,6 @@ function testHistory (t, db, key, expected, cb) {
     })
   })
   stream.on('end', () => {
-    // console.log('end')
     t.same(results.length, 0)
     cb()
   })

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -1,0 +1,62 @@
+var tape = require('tape')
+var toStream = require('nanoiterator/to-stream')
+
+var create = require('./helpers/create')
+var put = require('./helpers/put')
+var run = require('./helpers/run')
+var keyHistory = require('../lib/key-history')
+
+tape('empty db', (t) => {
+  var db = create.one()
+  run(
+    cb => testHistory(t, db, 'hello', [], cb),
+    t.end
+  )
+}, { timeout: 1000 })
+tape('single feed', (t) => {
+  var db = create.one()
+  run(
+    cb => put(db, [
+      { key: 'hello', value: 'welt' },
+      { key: 'null', value: 'void' },
+      { key: 'hello', value: 'world' }
+    ], cb),
+    cb => testHistory(t, db, 'hello', ['world', 'welt'], cb),
+    cb => testHistory(t, db, 'null', ['void'], cb),
+    t.end
+  )
+}, { timeout: 1000 })
+
+tape('two feeds', (t) => {
+  create.two((db1, db2, replicate) => {
+    run(
+      cb => put(db1, [
+        { key: 'hello', value: 'welt' },
+        { key: 'null', value: 'void' }
+      ], cb),
+      replicate,
+      cb => put(db2, [
+        { key: 'hello', value: 'world' }
+      ], cb),
+      replicate,
+      cb => testHistory(t, db1, 'hello', ['world', 'welt'], cb),
+      t.end
+    )
+  })
+}, { timeout: 1000 })
+
+function testHistory (t, db, key, expected, cb) {
+  const results = expected.slice(0)
+  const stream = toStream(keyHistory(db, key))
+  stream.on('data', (data) => {
+    console.log(data)
+    console.log(data[0].value)
+    t.same(data[0].value, results.shift())
+  })
+  stream.on('end', () => {
+    console.log('end')
+    t.same(results.length, 0)
+    cb()
+  })
+  stream.on('error', cb)
+}

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -1,6 +1,7 @@
 var tape = require('tape')
 var toStream = require('nanoiterator/to-stream')
 
+var replicate = require('./helpers/replicate')
 var create = require('./helpers/create')
 var put = require('./helpers/put')
 var run = require('./helpers/run')
@@ -13,6 +14,7 @@ tape('empty db', (t) => {
     t.end
   )
 }, { timeout: 1000 })
+
 tape('single feed', (t) => {
   var db = create.one()
   run(
@@ -23,6 +25,19 @@ tape('single feed', (t) => {
     ], cb),
     cb => testHistory(t, db, 'hello', ['world', 'welt'], cb),
     cb => testHistory(t, db, 'null', ['void'], cb),
+    t.end
+  )
+}, { timeout: 1000 })
+
+tape('single feed (same value)', (t) => {
+  var db = create.one()
+  run(
+    cb => put(db, [
+      { key: 'hello', value: 'welt' },
+      { key: 'hello', value: 'darkness' },
+      { key: 'hello', value: 'world' }
+    ], cb),
+    cb => testHistory(t, db, 'hello', ['world', 'darkness', 'welt'], cb),
     t.end
   )
 }, { timeout: 1000 })
@@ -45,16 +60,80 @@ tape('two feeds', (t) => {
   })
 }, { timeout: 1000 })
 
+tape('two feeds with conflict', (t) => {
+  create.two((db1, db2, replicate) => {
+    run(
+      cb => put(db1, [
+        { key: 'hello', value: 'welt' },
+        { key: 'null', value: 'void' }
+      ], cb),
+      cb => put(db2, [
+        { key: 'hello', value: 'world' }
+      ], cb),
+      replicate,
+      cb => testHistory(t, db1, 'hello', [['world', 'welt']], cb),
+      t.end
+    )
+  })
+}, { timeout: 1000 })
+
+tape('three feeds with conflict', (t) => {
+  create.three((db1, db2, db3, replicateAll) => {
+    run(
+      cb => put(db1, [
+        { key: 'hello', value: 'welt' },
+        { key: 'null', value: 'void' }
+      ], cb),
+      cb => replicate(db1, db2, cb),
+      cb => put(db2, [
+        { key: 'hello', value: 'world' }
+      ], cb),
+      cb => replicate(db1, db2, cb),
+      cb => put(db3, [
+        { key: 'hello', value: 'again' }
+      ], cb),
+      replicateAll,
+      cb => testHistory(t, db1, 'hello', [['world', 'again'], 'welt'], cb),
+      t.end
+    )
+  })
+}, { timeout: 1000 })
+
+tape('three feeds with all conflicting', (t) => {
+  create.three((db1, db2, db3, replicateAll) => {
+    run(
+      cb => put(db1, [
+        { key: 'hello', value: 'welt' },
+        { key: 'null', value: 'void' }
+      ], cb),
+      cb => put(db2, [
+        { key: 'hello', value: 'world' }
+      ], cb),
+      cb => put(db3, [
+        { key: 'hello', value: 'again' }
+      ], cb),
+      replicateAll,
+      cb => testHistory(t, db1, 'hello', [['world', 'again', 'welt']], cb),
+      t.end
+    )
+  })
+}, { timeout: 1000 })
+
 function testHistory (t, db, key, expected, cb) {
   const results = expected.slice(0)
   const stream = toStream(keyHistory(db, key))
   stream.on('data', (data) => {
-    console.log(data)
-    console.log(data[0].value)
-    t.same(data[0].value, results.shift())
+    var expected = results.shift()
+    // console.log(data, expected)
+    t.notEqual(expected, undefined)
+    if (!Array.isArray(expected)) expected = [expected]
+    t.same(data.length, expected.length)
+    expected.forEach((value, i) => {
+      t.same(data[i].value, value)
+    })
   })
   stream.on('end', () => {
-    console.log('end')
+    // console.log('end')
     t.same(results.length, 0)
     cb()
   })

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -140,7 +140,7 @@ tape('three feeds (again)', (t) => {
 
 function testHistory (t, db, key, expected, cb) {
   var results = expected.slice(0)
-  var stream = db.createHistoryStream(key)
+  var stream = db.createKeyHistoryStream(key)
   stream.on('data', (data) => {
     var expected = results.shift()
     t.notEqual(expected, undefined)

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -119,6 +119,27 @@ tape('three feeds with all conflicting', (t) => {
   })
 }, { timeout: 1000 })
 
+tape('three feeds (again)', (t) => {
+  const toVersion = v => ({ key: 'version', value: v })
+  create.three((db1, db2, db3, replicateAll) => {
+    const len = 5
+    const expected = []
+    for (var i = 0; i < len * 3; i++) {
+      expected.push(i.toString())
+    }
+    run(
+      cb => put(db1, expected.slice(0, len).map(toVersion), cb),
+      replicateAll,
+      cb => put(db2, expected.slice(len, len * 2).map(toVersion), cb),
+      replicateAll,
+      cb => put(db3, expected.slice(len * 2).map(toVersion), cb),
+      replicateAll,
+      cb => testHistory(t, db1, 'version', expected.reverse(), cb),
+      t.end
+    )
+  })
+}, { timeout: 1000 })
+
 function testHistory (t, db, key, expected, cb) {
   const results = expected.slice(0)
   const stream = toStream(keyHistory(db, key))


### PR DESCRIPTION
This is a simple PR to add the ability to stream the history of a specific prefix.

I want to be able to quickly iterate all values that a key has ever been.

I have write basic tests and it appears to be working, but I wanted to get your thoughts on this @mafintosh, to see if I am approaching the problem in the best way - or if there is a smarter way of traversing backwards.
