### PR TITLE
batch needs to normlize key

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ HyperDB.prototype.batch = function (batch, cb) {
         }
 
         var next = batch[i++]
-        put(self, clock, heads, next.key, next.value, {delete: next.type === 'del'}, loop)
+        put(self, clock, heads, normalizeKey(next.key), next.value, {delete: next.type === 'del'}, loop)
       }
 
       function done (err) {


### PR DESCRIPTION
batching doesn't normalize the key before calling put, and this leads to [isPrefix()](https://github.com/doraemondrian/hyperdb/blob/master/lib/iterator.js#L232) to return false later, resulting in `null` results for queries.