### PR TITLE
Document `createReadStream` reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Options include:
 {
   recursive: true // visit all subfolders.
                   // set to false to only visit the first node in each folder
+  reverse: true   // read the records in reverse order.
   gt: false       // visit only strictly nodes that are > than the prefix
 }
 ```


### PR DESCRIPTION
I was checking if the `reverse` option was already implemented in `./lib/iterator`, because I might need it for a project I'm working on. Turns out it is, so this patch adds this information to the API documentation for `createReadStream`.

I'm wondering though whether reading records in reverse order will affect performance, like it does in LevelDB. If thats the case I could add another line to the documentation to point that out.