### PR TITLE
Use Object.assign to ensure opts isn't mutated

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function HyperDB (storage, key, opts) {
     key = null
   }
 
-  if (!opts) opts = {}
+  opts = Object.assign({}, opts)
   if (opts.firstNode) opts.reduce = reduceFirst
 
   var checkout = opts.checkout
@@ -295,7 +295,7 @@ HyperDB.prototype.authorize = function (key, cb) {
 }
 
 HyperDB.prototype.replicate = function (opts) {
-  if (!opts) opts = {}
+  opts = Object.assign({}, opts)
 
   var self = this
   var expectedFeeds = Math.max(1, this._authorized.length)

--- a/test/basic.js
+++ b/test/basic.js
@@ -515,3 +515,10 @@ tape('can put/get a null value', function (t) {
     })
   })
 })
+
+tape('opts is not mutated', function (t) {
+  var opts = {firstNode: true}
+  create.one(opts)
+  t.deepEqual(opts, {firstNode: true})
+  t.end()
+})

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -298,6 +298,14 @@ tape('2 unauthed clones', function (t) {
   })
 })
 
+tape('opts is not mutated', function (t) {
+  var db = create.one()
+  var opts = {}
+  db.replicate(opts)
+  t.deepEqual(opts, {})
+  t.end()
+})
+
 function range (n) {
   return Array(n).join(',').split(',').map((_, i) => '' + i)
 }


### PR DESCRIPTION
Some users may re-use the opts object passed as a parameter,
which results in surprising behaviour protocol errors after multiple
calls to .replicate() eg. random errors such as:

 Only 128 feeds currently supported.
 Remote sent invalid feed message
 Remote message is larger than 8MB (max allowed)

There was also an instance of the opts object in the constructor
being mutated as well, so added an Object.assign for that as well.