### PR TITLE
Added ifNotExists option to put

### DIFF
--- a/lib/put.js
+++ b/lib/put.js
@@ -12,6 +12,7 @@ function PutRequest (db, key, value, clock, opts) {
   this.key = key
   this.value = value
   this.delete = !!(opts && opts.delete)
+  this.ifNotExists = !!(opts && opts.ifNotExists)
 
   this._clock = clock
   this._active = 0
@@ -166,7 +167,13 @@ PutRequest.prototype._moveCloser = function (worker) {
 
 PutRequest.prototype._end = function (worker, err) {
   if (err) this._error = err
-  if (!--this._active) this._finalize()
+  if (!--this._active) {
+    if (this.ifNotExists && worker.head.key === this.key) {
+      if (this._callback) return this._callback(err, worker.head)
+      return
+    }
+    this._finalize()
+  }
 }
 
 PutRequest.prototype._push = function (worker, val, feed, seq) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -535,26 +535,27 @@ tape('does not reinsert if isNotExists is true in put', function (t) {
 })
 
 tape('normal insertions work with ifNotExists', function (t) {
-  t.plan(7)
+  t.plan(5)
 
-  var db = create.one(null, {valueEncoding: 'utf8'})
-  db.put('some key', 'hello', { ifNotExists: true }, function (err) {
+  var db = create.one()
+  run(
+    cb => db.put('some key', 'hello', { ifNotExists: true }, cb),
+    cb => db.put('some key', 'goodbye', { ifNotExists: true }, cb),
+    cb => db.put('another key', 'something else', { ifNotExists: true }, cb),
+    done
+  )
+
+  function done (err) {
     t.error(err, 'no error')
-    db.put('some key', 'goodbye', { ifNotExists: true }, function (err) {
+    db.get('some key', function (err, node) {
       t.error(err, 'no error')
-      db.put('another key', 'something else', { ifNotExists: true }, function (err) {
+      t.same(node.value, 'hello')
+      db.get('another key', function (err, node) {
         t.error(err, 'no error')
-        db.get('some key', function (err, node) {
-          t.error(err, 'no error')
-          t.same(node.value, 'hello')
-          db.get('another key', function (err, node) {
-            t.error(err, 'no error')
-            t.same(node.value, 'something else')
-          })
-        })
+        t.same(node.value, 'something else')
       })
     })
-  })
+  }
 })
 
 tape('put with ifNotExists does not reinsert with conflict', function (t) {


### PR DESCRIPTION
For certain use-cases (particularly when keys are content-hashes of values), it'd be nice to be able to combine an existence check + the insertion into one operation. When the `ifNotExists` flag is set in `put`, the insertion will stop if it detects that the closest node has the same key as the one being inserted. With this approach, only one traversal is required to accomplish the above workflow.

The PR:
1. Adds the `ifNotExists` flag to `db.put`
2. Adds three tests (in `test/basic.js`) to ensure that this behavior works correctly (including in the presence of conflicts). 