### PR TITLE
add deletes option to iterator

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -35,6 +35,7 @@ function Iterator (db, prefix, opts) {
   this._map = options.map(opts, db)
   this._reduce = options.reduce(opts, db)
   this._collisions = []
+  this._deletes = !!(opts && opts.deletes)
 
   this._prefix = prefix
   this._pending = 0
@@ -106,7 +107,7 @@ Iterator.prototype._singleNode = function (top, cb) {
     return this._pending === 0
   }
 
-  if (node.deleted || !isPrefix(node.key, this._prefix)) return true
+  if ((!this._deletes && node.deleted) || !isPrefix(node.key, this._prefix)) return true
   cb(null, this._prereturn([node]))
   return false
 }
@@ -132,7 +133,7 @@ Iterator.prototype._multiNode = function (path, nodes, cb) {
   }
 
   nodes = this._filterResult(nodes, ptr)
-  if (nodes && !allDeletes(nodes)) return cb(null, this._prereturn(nodes))
+  if (nodes && (this._deletes || !allDeletes(nodes))) return cb(null, this._prereturn(nodes))
   this._next(cb)
 }
 
@@ -222,7 +223,7 @@ function visitTrie (nodes, ptr, val) {
 function drain (collisions) {
   while (collisions.length) {
     var collision = collisions.pop()
-    if (allDeletes(collision)) continue
+    if (!this._deletes && allDeletes(collision)) continue
     return collision
   }
 


### PR DESCRIPTION
This pr adds the delete option, which is available in the `get` method, to the `createReadStream` and `iterator` methods.

My main motivation for this change is so that I can see all values that have been added to the database regardless of whether they still exist or not. 

I need this functionality for [hyperdb-stage](https://github.com/e-e-e/hyperdb-stage) so that I can easily merge staged deletions. This PR will fix this currently broken test - https://github.com/e-e-e/hyperdb-stage/blob/master/test/staged.test.js#L174-L184