### PR TITLE
Added `update` option to do not wait for a remote update

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,18 @@ array of nodes returned from `db.heads`.
 
 Insert a new value. Will merge any previous values seen for this key.
 
-#### `db.get(key, callback)`
+#### `db.get(key[, options], callback)`
 
 Lookup a string `key`. Returns a nodes array with the current values for this key.
 If there is no current conflicts for this key the array will only contain a single node.
+
+Options include:
+
+```js
+{
+  update: true    // wait for a remote update if the db is empty (only for readers)
+}
+```
 
 #### `db.del(key, callback)`
 
@@ -186,6 +194,7 @@ Options include:
                   // set to false to only visit the first node in each folder
   reverse: true   // read the records in reverse order.
   gt: false       // visit only strictly nodes that are > than the prefix
+  update: true    // wait for a remote update if the db is empty (only for readers)
 }
 ```
 
@@ -223,11 +232,28 @@ Nodes are emitted in topographic order, meaning if value `v2` was aware of value
 
 To emit the nodes in reverse order pass `{reverse: true}` as an option.
 
+Options include:
+
+```js
+{
+  reverse: true   // read the records in reverse order.
+  update: true    // wait for a remote update if the db is empty (only for readers)
+}
+```
+
 #### `var stream = db.createKeyHistoryStream(key)`
 
 Returns a readable stream of node objects covering all historic values for a specific key.
 
 Results are returned with the latest value first.
+
+Options include:
+
+```js
+{
+  update: true    // wait for a remote update if the db is empty (only for readers)
+}
+```
 
 #### `var stream = db.replicate([options])`
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Options include:
 }
 ```
 
-#### `var stream = db.createKeyHistoryStream(key)`
+#### `var stream = db.createKeyHistoryStream(key[, options)`
 
 Returns a readable stream of node objects covering all historic values for a specific key.
 

--- a/index.js
+++ b/index.js
@@ -217,8 +217,13 @@ HyperDB.prototype.snapshot = function (opts) {
   return this.checkout(null, opts)
 }
 
-HyperDB.prototype.heads = function (cb) {
-  this._getHeads(true, cb)
+HyperDB.prototype.heads = function (update, cb) {
+  if (typeof update === 'function') {
+    cb = update
+    update = true
+  }
+
+  this._getHeads(update, cb)
 }
 
 HyperDB.prototype._getHeads = function (update, cb) {

--- a/lib/history.js
+++ b/lib/history.js
@@ -9,6 +9,7 @@ function Iterator (db, opts) {
 
   this._db = db
   this._reverse = !!(opts && opts.reverse)
+  this._update = opts && opts.update !== undefined ? opts.update : true
   this._end = []
   this._nodes = []
 }
@@ -18,7 +19,7 @@ inherits(Iterator, nanoiterator)
 Iterator.prototype._open = function (cb) {
   var self = this
 
-  this._db.heads(function (err, heads) {
+  this._db.heads(self._update, function (err, heads) {
     if (err) return cb(err)
 
     var writers = self._db._writers

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -36,6 +36,7 @@ function Iterator (db, prefix, opts) {
   this._reduce = options.reduce(opts, db)
   this._collisions = []
   this._deletes = !!(opts && opts.deletes)
+  this._update = opts && opts.update !== undefined ? opts.update : true
 
   this._prefix = prefix
   this._pending = 0
@@ -179,7 +180,7 @@ Iterator.prototype._next = function (cb) {
 Iterator.prototype._lookupPrefix = function (path, cb) {
   var self = this
 
-  this._db.get('', {path, prefix: true, map: false, reduce: false}, done)
+  this._db.get('', {path, prefix: true, map: false, reduce: false, update: self._update}, done)
 
   function done (err, nodes) {
     if (err) return cb(err)

--- a/lib/key-history.js
+++ b/lib/key-history.js
@@ -10,13 +10,16 @@ function Iterator (db, prefix, opts) {
   nanoiterator.call(this)
   this._db = db
   this._prefix = normalizeKey(prefix)
+  this._update = opts && opts.update !== undefined ? opts.update : true
   this._heads = undefined
 }
 
 inherits(Iterator, nanoiterator)
 
 Iterator.prototype._open = function (cb) {
-  this._db.heads((err, heads) => {
+  var self = this
+
+  this._db.heads(self._update, (err, heads) => {
     if (err) return cb(err)
     this._heads = heads
     cb()

--- a/test/history.js
+++ b/test/history.js
@@ -128,3 +128,40 @@ tape('reverse', function (t) {
     }
   })
 })
+
+tape('empty history, being reader with update in true', function (t) {
+  var a = create.one()
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createHistoryStream({ update: true })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.notOk(callEnd, 'the stream should stay open and waiting for remote updates')
+      t.end()
+    })
+  })
+})
+
+tape('empty history, being reader with update in false', function (t) {
+  var a = create.one()
+
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createHistoryStream({ update: false })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.ok(callEnd, 'the stream should end and not wait for remote updates')
+      t.end()
+    })
+  })
+})

--- a/test/key-history.js
+++ b/test/key-history.js
@@ -1,5 +1,4 @@
 var tape = require('tape')
-
 var replicate = require('./helpers/replicate')
 var create = require('./helpers/create')
 var put = require('./helpers/put')
@@ -137,6 +136,43 @@ tape('three feeds (again)', (t) => {
     )
   })
 }, { timeout: 1000 })
+
+tape('empty key history, being reader with update in true', function (t) {
+  var a = create.one()
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createHistoryStream('keyTest', { update: true })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.notOk(callEnd, 'the stream should stay open and waiting for remote updates')
+      t.end()
+    })
+  })
+})
+
+tape('empty key history, being reader with update in false', function (t) {
+  var a = create.one()
+
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createKeyHistoryStream('keyTest', { update: false })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.ok(callEnd, 'the stream should end and not wait for remote updates')
+      t.end()
+    })
+  })
+})
 
 function testHistory (t, db, key, expected, cb) {
   var results = expected.slice(0)

--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -206,3 +206,40 @@ tape('returns no data if db is empty', function (t) {
     t.end()
   })
 })
+
+tape('db is empty, being reader with update in true', function (t) {
+  var a = create.one()
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createReadStream({ update: true })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.notOk(callEnd, 'the stream should stay open and waiting for remote updates')
+      t.end()
+    })
+  })
+})
+
+tape('db is empty, being reader with update in false', function (t) {
+  var a = create.one()
+
+  a.ready(function () {
+    var b = create.one(a.key)
+    var rs = b.createReadStream({ update: false })
+    var callEnd = false
+    rs.on('data', () => {})
+    rs.on('end', () => {
+      callEnd = true
+    })
+
+    setTimeout(() => {
+      t.ok(callEnd, 'the stream should end and not wait for remote updates')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
The readable stream works differently if you are a writer or a reader in an empty database.

If I'm a reader on a hyperdb and I never had the chance of replicate with others peers yet. When I try to create a readable stream I would expect an error or an end of stream.

Like when you try to read a file and is not there: ENOENT

This is a way to allow this behavior without sacrifice the original idea of hyperdb.

The `get` method has an undocumented `update` option that if hyperdb doesn't have `heads` yet wait or not for a remote update.

I add this option to the rest of the reader methods like createReadStream and createHistoryStream.