### PR TITLE
WIP: Add audit method to fix corrupted databases

### DIFF
--- a/index.js
+++ b/index.js
@@ -586,7 +586,7 @@ HyperDB.prototype.audit = function (cb) {
 
   function finish () {
     var errs = results.map(r => r.err).filter(r => r)
-    if (errs) cb(errs, results)
+    if (errs.length) cb(errs, results)
     else cb(null, results)
   }
 }

--- a/index.js
+++ b/index.js
@@ -562,6 +562,35 @@ HyperDB.prototype.createWriteStream = function (cb) {
   }
 }
 
+HyperDB.prototype.audit = function (cb) {
+  var self = this
+  var results = []
+  var len
+
+  audit()
+
+  function audit () {
+    len = self._writers.length
+    self._writers.forEach(function (writer) {
+      var feed = writer._feed
+      feed.audit(collect(feed.key))
+    })
+  }
+
+  function collect (key) {
+    return function (err, res) {
+      results.push({ key, err, res })
+      if (results.length === len) finish()
+    }
+  }
+
+  function finish () {
+    var errs = results.map(r => r.err).filter(r => r)
+    if (errs) cb(errs, results)
+    else cb(null, results)
+  }
+}
+
 HyperDB.prototype._ready = function (cb) {
   var self = this
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bulk-write-stream": "^1.1.3",
     "codecs": "^1.2.1",
     "compare": "^2.0.0",
-    "hypercore": "^6.13.0",
+    "hypercore": "^6.21.0",
     "hypercore-protocol": "^6.6.4",
     "inherits": "^2.0.3",
     "mutexify": "^1.2.0",


### PR DESCRIPTION
This adds an audit method that calls hypercore's recently added audit method on all writers. It should remove corrupted blocks. Does not work currently because after an audit that resulted in the removal of a block the reported length of the hypercore is wrong. @mafintosh is working on a fix in hypercore for this.