### PR TITLE
Reproducible local writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ Options include:
   map: node => mappedNode, // map nodes before returning them
   reduce: (a, b) => someNode, // reduce the nodes array before returning it
   firstNode: false, // set to true to reduce the nodes array to the first node in it
-  valueEncoding: 'binary' // set the value encoding of the db
+  valueEncoding: 'binary', // set the value encoding of the db
+  localKey: localKeyBuffer, // public key to use for the local writer
+  localSecretKey: localSecretKeyBuffer // secret key to use for the local writer
 }
 ```
+
+The `localKey` and `localSecretKey` options are useful when you need reproducible local writers (for example to recreate a database). If they are not provided, a new key pair will be generated for the local writer. If provided, both keys must be provided together.
 
 #### `db.key`
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ function HyperDB (storage, key, opts) {
   this._watching = checkout ? checkout._watching : []
   this._replicating = []
   this._localWriter = null
+  this._localKey = opts.localKey || null
+  this._localSecretKey = opts.localSecretKey || null
   this._byKey = new Map()
   this._heads = opts.heads || null
   this._version = opts.version || null
@@ -582,7 +584,7 @@ HyperDB.prototype._ready = function (cb) {
   this.source.ready(function (err) {
     if (err) return done(err)
     if (self.source.writable) self.local = self.source
-    if (!self.local) self.local = feed('local')
+    if (!self.local) self.local = feed('local', self._localKey, { secretKey: self._localSecretKey })
 
     self.key = self.source.key
     self.discoveryKey = self.source.discoveryKey

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,10 +5,11 @@ var create = require('./helpers/create')
 var run = require('./helpers/run')
 
 tape('reproducible local hypercore', function (t) {
+  var key = Buffer.from('de14f28853123596830410a371b38bd4768fcb95880142e9e54a00aa8c418158', 'hex')
   var localKey = Buffer.from('c575d78d42d42b88db80c3b66ba6cacdb0e633f98e375226b23788c5d5dd4a17', 'hex')
   var localSecretKey = Buffer.from('778e1ed4513175ebac7cfcc97dbde5bd87795c990811784e85de0abc3b2da36ac575d78d42d42b88db80c3b66ba6cacdb0e633f98e375226b23788c5d5dd4a17', 'hex')
 
-  var db = create.one(null, {
+  var db = create.one(key, {
     localKey,
     localSecretKey
   })

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,6 +4,22 @@ var Readable = require('stream').Readable
 var create = require('./helpers/create')
 var run = require('./helpers/run')
 
+tape('reproducible local hypercore', function (t) {
+  var localKey = Buffer.from('c575d78d42d42b88db80c3b66ba6cacdb0e633f98e375226b23788c5d5dd4a17', 'hex')
+  var localSecretKey = Buffer.from('778e1ed4513175ebac7cfcc97dbde5bd87795c990811784e85de0abc3b2da36ac575d78d42d42b88db80c3b66ba6cacdb0e633f98e375226b23788c5d5dd4a17', 'hex')
+
+  var db = create.one(null, {
+    localKey,
+    localSecretKey
+  })
+
+  db.on('ready', function () {
+    t.same(db.local.key, localKey)
+    t.same(db.local.secretKey, localSecretKey)
+    t.end()
+  })
+})
+
 tape('basic put/get', function (t) {
   var db = create.one()
   db.put('hello', 'world', function (err, node) {


### PR DESCRIPTION
## Summary of changes:

Adds two (optional) options to the options object you can pass when creating a hyperdb to support reproducible local writers:

  * `localKey`
  * `localSecretKey`

If present, these are used when creating the local writer instead of randomly choosing a keypair.

This is a non-breaking change. If the local writer key details are not passed in, hyperdb works as before.

## Use case: 

In a multiwriter system, once a writer (e.g., a browser node) has been authorised, we do not want it to have to re-apply for authorisation if the local database is destroyed (e.g., local data is cleared) as this adds a non-trivial experience cost to the person using the system. The alternative is to create a new writer every time which also adds to the overhead of the hyperdb. 

This pull request makes it possible to implement seamless device/node authorisation for multiwriter when used in conjuction with passphrase-derived keys and a module like [secure-ephemeral-messaging-channel](https://source.ind.ie/hypha/secure-ephemeral-messaging-channel).

## Links:

  * https://ar.al/2019/01/22/hypha-spike-multiwriter-1/
  * https://ar.al/2019/02/01/hypha-spike-multiwriter-2/

Closes #158